### PR TITLE
KAIZEN-0 Utvider med eget endepunkt for kontaktinformasjon

### DIFF
--- a/src/main/java/no/nav/fo/veilarbperson/domain/person/Kontaktinfo.java
+++ b/src/main/java/no/nav/fo/veilarbperson/domain/person/Kontaktinfo.java
@@ -1,0 +1,23 @@
+package no.nav.fo.veilarbperson.domain.person;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import no.nav.fo.veilarbperson.consumer.digitalkontaktinformasjon.DigitalKontaktinformasjon;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Accessors(chain = true)
+public class Kontaktinfo {
+
+    private String epost;
+    private String telefon;
+
+    public static Kontaktinfo fraKrr(DigitalKontaktinformasjon digitalKontaktinformasjon) {
+        return new Kontaktinfo()
+                .setEpost(digitalKontaktinformasjon.getEpost())
+                .setTelefon(digitalKontaktinformasjon.getTelefon());
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbperson/utils/MapKrrExceptionUtil.java
+++ b/src/main/java/no/nav/fo/veilarbperson/utils/MapKrrExceptionUtil.java
@@ -1,0 +1,26 @@
+package no.nav.fo.veilarbperson.utils;
+
+import no.nav.apiapp.feil.Feil;
+import no.nav.apiapp.feil.FeilType;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonKontaktinformasjonIkkeFunnet;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonPersonIkkeFunnet;
+import no.nav.tjeneste.virksomhet.digitalkontaktinformasjon.v1.HentDigitalKontaktinformasjonSikkerhetsbegrensing;
+
+public class MapKrrExceptionUtil {
+
+    public static Feil map(Throwable error) {
+
+        FeilType feilType;
+        if (error instanceof HentDigitalKontaktinformasjonKontaktinformasjonIkkeFunnet) {
+            feilType = FeilType.FINNES_IKKE;
+        } else if (error instanceof HentDigitalKontaktinformasjonPersonIkkeFunnet) {
+            feilType = FeilType.INGEN_TILGANG;
+        } else if (error instanceof HentDigitalKontaktinformasjonSikkerhetsbegrensing) {
+            feilType = FeilType.INGEN_TILGANG;
+        } else {
+            feilType = FeilType.UKJENT;
+        }
+
+        return new Feil(feilType, error);
+    }
+}


### PR DESCRIPTION
Arbeidssøkerregistrering har behov for å vise kontaktinfo (telefon/e-post) til sluttbruker i tilfeller hvor bruker får mulighet til å opprette "kontakt bruker"-oppgave som følge av manglende arbeids-/oppholdstillatelse i Arena.