### PR TITLE
TK-80: La et ny endepunkt til å hente personnavn fra pdl

### DIFF
--- a/src/main/java/no/nav/veilarbperson/client/pdl/domain/Adresse.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/domain/Adresse.java
@@ -1,7 +1,5 @@
 package no.nav.veilarbperson.client.pdl.domain;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;

--- a/src/main/java/no/nav/veilarbperson/client/pdl/domain/PersonNavn.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/domain/PersonNavn.java
@@ -1,0 +1,13 @@
+package no.nav.veilarbperson.client.pdl.domain;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+public class PersonNavn {
+    private String fornavn;
+    private String mellomnavn;
+    private String etternavn;
+    private String forkortetNavn;
+}

--- a/src/main/java/no/nav/veilarbperson/controller/PersonV2Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/PersonV2Controller.java
@@ -3,6 +3,7 @@ package no.nav.veilarbperson.controller;
 import io.swagger.annotations.ApiOperation;
 import no.nav.common.types.identer.Fnr;
 import no.nav.veilarbperson.client.pdl.PersonV2Data;
+import no.nav.veilarbperson.client.pdl.domain.PersonNavn;
 import no.nav.veilarbperson.client.pdl.domain.TilrettelagtKommunikasjonData;
 import no.nav.veilarbperson.client.pdl.domain.VergeOgFullmaktData;
 import no.nav.veilarbperson.domain.Malform;
@@ -59,5 +60,13 @@ public class PersonV2Controller {
         authService.stoppHvisEksternBruker();
         authService.sjekkLesetilgang(fnr);
         return personV2Service.hentSpraakTolkInfo(fnr, authService.getInnloggetBrukerToken());
+    }
+
+    @GetMapping("/navn")
+    @ApiOperation(value = "Henter navn til en person fra PDL")
+    public PersonNavn hentNavn(@RequestParam("fnr") Fnr fnr) {
+        authService.stoppHvisEksternBruker();
+        authService.sjekkLesetilgang(fnr);
+        return personV2Service.hentNavn(fnr, authService.getInnloggetBrukerToken());
     }
 }

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -276,4 +276,11 @@ public class PersonV2Service {
         }
         return null;
     }
+
+    public PersonNavn hentNavn(Fnr fnr, String userToken) {
+        HentPdlPerson.PersonNavn personNavn = ofNullable(pdlClient.hentPersonNavn(fnr, userToken))
+                .orElseThrow(()-> new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Klarte ikke å hente personsnavn"));
+
+        return PersonV2DataMapper.hentNavn(personNavn.getNavn());
+    }
 }

--- a/src/main/java/no/nav/veilarbperson/utils/PersonV2DataMapper.java
+++ b/src/main/java/no/nav/veilarbperson/utils/PersonV2DataMapper.java
@@ -43,10 +43,10 @@ public class PersonV2DataMapper {
         return list.stream().findFirst().orElse(null);
     }
 
-    public static HentPdlPerson.Navn hentNavn(List<HentPdlPerson.Navn> personNavn) {
+    public static PersonNavn hentNavn(List<HentPdlPerson.Navn> personNavn) {
         HentPdlPerson.Navn navn = getFirstElement(personNavn);
 
-        return new HentPdlPerson.Navn()
+        return new PersonNavn()
                 .setFornavn(ofNullable(navn).map(HentPdlPerson.Navn::getFornavn).orElse(null))
                 .setMellomnavn(ofNullable(navn).map(HentPdlPerson.Navn::getMellomnavn).orElse(null))
                 .setEtternavn(ofNullable(navn).map(HentPdlPerson.Navn::getEtternavn).orElse(null))

--- a/src/main/resources/graphql/hentTilrettelagtKommunikasjon.gql
+++ b/src/main/resources/graphql/hentTilrettelagtKommunikasjon.gql
@@ -1,6 +1,6 @@
 query($ident: ID!, $historikk: Boolean!) {
     hentPerson(ident: $ident) {
-        tilrettelagtKommunikasjon(historikk: $historikk) {
+        tilrettelagtKommunikasjon {
             talespraaktolk {
                 spraak
             }

--- a/src/test/java/no/nav/veilarbperson/service/PersonV2ServiceTest.java
+++ b/src/test/java/no/nav/veilarbperson/service/PersonV2ServiceTest.java
@@ -344,6 +344,13 @@ public class PersonV2ServiceTest extends PdlClientTestConfig {
         assertEquals("NORDMANN OLA", fullmaktListe.get(0).getMotpartsPersonNavn().getForkortetNavn());
     }
 
+    @Test
+    public void personNavnMapperTest() {
+        PersonNavn navn = PersonV2DataMapper.hentNavn(hentPersonNavn(FNR).getNavn());
+        assertEquals("OLA", navn.getFornavn());
+        assertEquals("NORDMANN", navn.getEtternavn());
+        assertEquals("NORDMANN OLA", navn.getForkortetNavn());
+    }
 
     @Test
     public void hentSpraakTolkInfoTest() {


### PR DESCRIPTION
- La et ny endepunkt til å hente personnavn fra PDL
- Fjernet unødvendig argument til tlrettelagtKommunikasjon 