### PR TITLE
Endre fra pdl-api-q1 til pdl-api i dev

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
@@ -64,7 +64,7 @@ public class ClientConfig {
     public AktorOppslagClient aktorOppslagClient(SystemUserTokenProvider systemUserTokenProvider) {
         String pdlUrl = isProduction()
                 ? createProdInternalIngressUrl("pdl-api")
-                : createDevInternalIngressUrl("pdl-api-q1");
+                : createDevInternalIngressUrl("pdl-api");
 
         no.nav.common.client.pdl.PdlClientImpl pdlClient = new no.nav.common.client.pdl.PdlClientImpl(
                 pdlUrl,


### PR DESCRIPTION
Sliter mye med at vi ikke finner brukere vi har opprettet i pdl-api-q1. Tror dette alternativet vil være mer stabilt.