### PR TITLE
Bruk veilarbregistrering i gcp i dev

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
@@ -157,9 +157,10 @@ public class ClientConfig {
     public VeilarbregistreringClient veilarbregistreringClient(
             AzureAdMachineToMachineTokenClient aadMachineToMachineTokenClient
     ) {
+        String cluster = isProduction() ? "prod-fss" : "dev-gcp";
         Supplier<String> serviceTokenSupplier = () -> aadMachineToMachineTokenClient
                 .createMachineToMachineToken(
-                        format("api://%s.%s.%s/.default", requireClusterName(), "paw", "veilarbregistrering"));
+                        format("api://%s.%s.%s/.default", cluster, "paw", "veilarbregistrering"));
 
         return new VeilarbregistreringClientImpl(
                 RestClient.baseClient(),


### PR DESCRIPTION
GCP-appen bruker nå den vanlige `veilarbregistrering.dev.intern.nav.no`- ingressen, så trenger ikke bytte ut denne :) 