### PR TITLE
Bruk veilarbregistrering i gcp i prod

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
@@ -46,7 +46,6 @@ import org.springframework.context.annotation.Configuration;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
-import static no.nav.common.utils.EnvironmentUtils.requireClusterName;
 import static no.nav.common.utils.NaisUtils.getCredentials;
 import static no.nav.common.utils.UrlUtils.*;
 
@@ -157,14 +156,15 @@ public class ClientConfig {
     public VeilarbregistreringClient veilarbregistreringClient(
             AzureAdMachineToMachineTokenClient aadMachineToMachineTokenClient
     ) {
-        String cluster = isProduction() ? "prod-fss" : "dev-gcp";
+        String cluster = isProduction() ? "prod-gcp" : "dev-gcp";
+        String appname = isProduction() ? "veilarbregistrering-gcp" : "veilarbregistrering";
         Supplier<String> serviceTokenSupplier = () -> aadMachineToMachineTokenClient
                 .createMachineToMachineToken(
                         format("api://%s.%s.%s/.default", cluster, "paw", "veilarbregistrering"));
 
         return new VeilarbregistreringClientImpl(
                 RestClient.baseClient(),
-                createInternalIngressUrl("veilarbregistrering"),
+                createInternalIngressUrl(appname),
                 serviceTokenSupplier
         );
     }


### PR DESCRIPTION
veilarbregistrering har en midlertidig ingress i prod, denne kommer til å bli endret neste uke når vi har fått all trafikk over og sletter fss-appen.

Vi vil flytte POST-kall for å registrere brukere mandag 16. januar. Frem til det migrerer vi data fra FSS til GCP løpende. Dersom dere merger denne før mandag, vær obs på at det vil det være opp til et par minutter forsinkelse på dataen i GCP. Migreringsjobben vår flytter data hvert 3. minutt, dvs at nye registreringer vil ligge tilgjengelig i GCP innen ~3 minutter. Etter flytten på mandag, vil ikke lenger fss-appen gi dere oppdatert data da vi ikke kommer til å replikere data tilbake til Oracle/FSS. Denne PR-en bør dermed gå ut i prod senest mandag :) 