### PR TITLE
Endre kodeverkklienten til å lagre term ikke tekst

### DIFF
--- a/src/main/java/no/nav/veilarbperson/client/kodeverk/KodeverkClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/kodeverk/KodeverkClientImpl.java
@@ -92,7 +92,7 @@ public class KodeverkClientImpl implements KodeverkClient {
 
                 JsonNode betydningBeskrivelserNode = betydningNyeste.get("beskrivelser");
                 JsonNode beskrivelseNbNode = betydningBeskrivelserNode.get("nb");
-                String beskrivelseNb = beskrivelseNbNode.get("tekst").asText();
+                String beskrivelseNb = beskrivelseNbNode.get("term").asText();
 
                 betydningerMap.put(betydningName, beskrivelseNb);
             });


### PR DESCRIPTION
[FAGSYSTEM-261456](https://jira.adeo.no/browse/FAGSYSTEM-261456)
Så å si ingen koder i kodeverkene har noe i feltet `tekst`, det virker som om det sendes akkurat det samme som står i `term`, MEN noen få koder har blankt tekst-felt, endrer derfor til å bruke `term`, som vi trolig burde brukt fra starten.