### PR TITLE
Prioritize azure login over loginservice

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/FilterConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/FilterConfig.java
@@ -60,8 +60,8 @@ public class FilterConfig {
         FilterRegistrationBean<OidcAuthenticationFilter> registration = new FilterRegistrationBean<>();
         OidcAuthenticationFilter authenticationFilter = new OidcAuthenticationFilter(
                 fromConfigs(
-                        loginserviceIdportenConfig(properties),
-                        naisAzureAdConfig(properties)
+                        naisAzureAdConfig(properties),
+                        loginserviceIdportenConfig(properties)
                 )
         );
 


### PR DESCRIPTION
Så lenge man har en id-porten cookie fra feks dev.nav.no så er det den som blir brukt til auth først siden det filteret ligger først i listen. Da tror veilarbperson at man er en eksternbruker istedetfor veileder
![Skjermbilde 2023-04-26 kl  13 45 30](https://user-images.githubusercontent.com/7754140/234565214-aea39174-490d-4e56-b35a-11ec0d60e022.png)
![Skjermbilde 2023-04-26 kl  13 47 10](https://user-images.githubusercontent.com/7754140/234565574-05fb629b-d4f6-4855-ae77-559b08370dd2.png)
