### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <java.version>17</java.version>
         <common.version>3.2023.05.25_12.58-6d52407f804a</common.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>
-        <kotlin.version>1.8.21</kotlin.version>
+        <kotlin.version>1.9.0</kotlin.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Hopper over Kotlin 1.8.22, direkte til 1.9.0