### PR TITLE
API endringer i registreringsdata

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -112,6 +112,10 @@ spec:
       value: api://dev-gcp.okonomi.sokos-kontoregister-person/.default
     - name: KONTOREGISTER_PERSON_V1_URL
       value: https://sokos-kontoregister-person.intern.dev.nav.no
+    - name: AIA_BACKEND_URL
+      value: https://www.intern.dev.nav.no/aia-backend
+    - name: AIA_BACKEND_SCOPE
+      value: api://dev-gcp.paw.paw-arbeidssoker-besvarelse/.default
   envFrom:
     - configmap: pto-config
     - configmap: loginservice-idporten

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -109,6 +109,10 @@ spec:
       value: api://prod-gcp.okonomi.sokos-kontoregister-person/.default
     - name: KONTOREGISTER_PERSON_V1_URL
       value: https://sokos-kontoregister-person.intern.nav.no
+    - name: AIA_BACKEND_URL
+      value: https://www.nav.no/aia-backend
+    - name: AIA_BACKEND_SCOPE
+      value: api://prod-gcp.paw.paw-arbeidssoker-besvarelse/.default
   envFrom:
     - configmap: pto-config
     - configmap: loginservice-idporten

--- a/src/main/java/no/nav/veilarbperson/client/aiabackend/AiaBackendClient.kt
+++ b/src/main/java/no/nav/veilarbperson/client/aiabackend/AiaBackendClient.kt
@@ -1,0 +1,8 @@
+package no.nav.veilarbperson.client.aiabackend
+
+import no.nav.common.health.HealthCheck
+import okhttp3.Response
+
+interface AiaBackendClient : HealthCheck {
+    fun hentEndringIRegistreringsdata(endringIRegistreringsdataRequestDTO: EndringIRegistreringsdataRequestDTO) : Response
+}

--- a/src/main/java/no/nav/veilarbperson/client/aiabackend/AiaBackendClientImpl.kt
+++ b/src/main/java/no/nav/veilarbperson/client/aiabackend/AiaBackendClientImpl.kt
@@ -1,0 +1,37 @@
+package no.nav.veilarbperson.client.aiabackend
+
+import lombok.SneakyThrows
+import no.nav.common.health.HealthCheckResult
+import no.nav.common.health.HealthCheckUtils
+import no.nav.common.rest.client.RestClient
+import no.nav.common.rest.client.RestUtils
+import no.nav.common.utils.UrlUtils.joinPaths
+import org.springframework.http.HttpHeaders.ACCEPT
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import no.nav.veilarbperson.utils.toJson
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.springframework.http.HttpHeaders
+import java.util.function.Supplier
+
+class AiaBackendClientImpl(private val aiaBackendUrl: String, private val userTokenSupplier: Supplier<String>) : AiaBackendClient {
+    private val client: OkHttpClient = RestClient.baseClient()
+
+    @SneakyThrows
+    override fun hentEndringIRegistreringsdata(endringIRegistreringsdataRequestDTO: EndringIRegistreringsdataRequestDTO) : Response {
+        val request = Request.Builder()
+            .url(joinPaths(aiaBackendUrl, "/veileder/besvarelse"))
+            .header(HttpHeaders.AUTHORIZATION, userTokenSupplier.get())
+            .header(ACCEPT, APPLICATION_JSON_VALUE)
+            .post(endringIRegistreringsdataRequestDTO.toJson().toRequestBody(RestUtils.MEDIA_TYPE_JSON))
+            .build()
+
+        return client.newCall(request).execute()
+    }
+
+    override fun checkHealth(): HealthCheckResult {
+        return HealthCheckUtils.pingUrl(joinPaths(aiaBackendUrl, "/internal/isReady"), client)
+    }
+}

--- a/src/main/java/no/nav/veilarbperson/client/aiabackend/EndringIRegistreringsdataRequestDTO.kt
+++ b/src/main/java/no/nav/veilarbperson/client/aiabackend/EndringIRegistreringsdataRequestDTO.kt
@@ -1,0 +1,5 @@
+package no.nav.veilarbperson.client.aiabackend
+
+data class EndringIRegistreringsdataRequestDTO(
+    val foedselsnummer: String
+)

--- a/src/main/java/no/nav/veilarbperson/client/regoppslag/RegoppslagClientImpl.kt
+++ b/src/main/java/no/nav/veilarbperson/client/regoppslag/RegoppslagClientImpl.kt
@@ -7,6 +7,8 @@ import no.nav.common.rest.client.RestUtils
 import no.nav.common.types.identer.Fnr
 import no.nav.common.utils.AuthUtils
 import no.nav.common.utils.UrlUtils
+import no.nav.veilarbperson.utils.deserializeJsonOrThrow
+import no.nav.veilarbperson.utils.toJson
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody

--- a/src/main/java/no/nav/veilarbperson/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ApplicationConfig.java
@@ -2,7 +2,6 @@ package no.nav.veilarbperson.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.common.abac.Pep;
 import no.nav.common.abac.VeilarbPepFactory;
@@ -24,7 +23,6 @@ import no.nav.poao_tilgang.client.PoaoTilgangCachedClient;
 import no.nav.poao_tilgang.client.PoaoTilgangClient;
 import no.nav.poao_tilgang.client.PoaoTilgangHttpClient;
 import no.nav.poao_tilgang.client.PolicyInput;
-import no.nav.veilarbperson.client.regoppslag.JsonUtils;
 import no.nav.veilarbperson.client.regoppslag.RegoppslagClient;
 import no.nav.veilarbperson.client.regoppslag.RegoppslagClientImpl;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -103,9 +101,4 @@ public class ApplicationConfig {
 	AuditLogger auditLogger() {
 		return new AuditLoggerImpl();
 	}
-
-    @PostConstruct
-    public void initJsonUtils() {
-        JsonUtils.init();
-    }
 }

--- a/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
@@ -14,6 +14,8 @@ import no.nav.common.token_client.builder.AzureAdTokenClientBuilder;
 import no.nav.common.token_client.client.AzureAdMachineToMachineTokenClient;
 import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
 import no.nav.common.token_client.client.MachineToMachineTokenClient;
+import no.nav.veilarbperson.client.aiabackend.AiaBackendClient;
+import no.nav.veilarbperson.client.aiabackend.AiaBackendClientImpl;
 import no.nav.veilarbperson.client.digdir.DigdirClient;
 import no.nav.veilarbperson.client.digdir.DigdirClientImpl;
 import no.nav.veilarbperson.client.kodeverk.KodeverkClient;
@@ -55,6 +57,13 @@ public class ClientConfig {
     public VeilarboppfolgingClient veilarboppfolgingClient(EnvironmentProperties properties, AuthService authService) {
         return new VeilarboppfolgingClientImpl(properties.getVeilarboppfolgingUrl(),
                 () -> authService.getAadOboTokenForTjeneste(properties.getVeilarboppfolgingScope()));
+    }
+
+    @Bean
+    public AiaBackendClient aiaBackendClient(EnvironmentProperties environmentProperties, AuthService authService) {
+        return new AiaBackendClientImpl(
+                environmentProperties.getAiaBackendUrl(),
+                () -> authService.getAadOboTokenForTjeneste(environmentProperties.getAiaBackendScope()));
     }
 
     @Bean

--- a/src/main/java/no/nav/veilarbperson/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarbperson/config/EnvironmentProperties.java
@@ -37,4 +37,6 @@ public class EnvironmentProperties {
     private String veilarbregistreringUrl;
     private String kontoregisterScope;
     private String kontoregisterUrl;
+    private String aiaBackendUrl;
+    private String aiaBackendScope;
 }

--- a/src/main/java/no/nav/veilarbperson/controller/PersonController.java
+++ b/src/main/java/no/nav/veilarbperson/controller/PersonController.java
@@ -85,6 +85,13 @@ public class PersonController {
         return registreringService.hentRegistrering(fnr);
     }
 
+    @GetMapping("/registrering/endringer")
+    public ResponseEntity<String> endringIRegistreringdata(@RequestParam(value = "fnr") Fnr fnr) {
+        authService.stoppHvisEksternBruker();
+        authService.sjekkLesetilgang(fnr);
+        return registreringService.hentEndringIRegistreringsdata(fnr);
+    }
+
     // TODO: Det er hårete å måtte skille på ekstern og intern
     //  Lag istedenfor en egen controller for interne operasjoner og en annen for eksterne
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {

--- a/src/main/java/no/nav/veilarbperson/service/RegistreringService.java
+++ b/src/main/java/no/nav/veilarbperson/service/RegistreringService.java
@@ -3,6 +3,8 @@ package no.nav.veilarbperson.service;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarbperson.client.aiabackend.AiaBackendClient;
+import no.nav.veilarbperson.client.aiabackend.EndringIRegistreringsdataRequestDTO;
 import no.nav.veilarbperson.client.veilarbregistrering.VeilarbregistreringClient;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -14,10 +16,28 @@ import org.springframework.stereotype.Service;
 public class RegistreringService {
 
     private final VeilarbregistreringClient client;
+    private final AiaBackendClient aiaBackendClient;
 
     @SneakyThrows
     public ResponseEntity<String> hentRegistrering(Fnr fnr) {
         try (Response response = client.hentRegistrering(fnr);
+             ResponseBody responseBody = response.body()) {
+
+            String bodyString = null;
+
+            if (responseBody != null) {
+                bodyString = responseBody.string();
+            }
+
+            return ResponseEntity
+                    .status(response.code())
+                    .body(bodyString);
+        }
+    }
+
+    @SneakyThrows
+    public ResponseEntity<String> hentEndringIRegistreringsdata(Fnr fnr) {
+        try (Response response = aiaBackendClient.hentEndringIRegistreringsdata(new EndringIRegistreringsdataRequestDTO(fnr.get()));
              ResponseBody responseBody = response.body()) {
 
             String bodyString = null;

--- a/src/main/java/no/nav/veilarbperson/utils/JsonUtils.kt
+++ b/src/main/java/no/nav/veilarbperson/utils/JsonUtils.kt
@@ -1,7 +1,6 @@
-package no.nav.veilarbperson.client.regoppslag
+package no.nav.veilarbperson.utils
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import no.nav.common.rest.client.RestUtils
 import okhttp3.Response
@@ -9,10 +8,6 @@ import okhttp3.Response
 object JsonUtils {
     val objectMapper: ObjectMapper =
         no.nav.common.json.JsonUtils.getMapper().registerModule(KotlinModule.Builder().build())
-
-    @JvmStatic
-    fun init() {
-    }
 }
 
 inline fun <reified T> Response.deserializeJson(): T? {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,6 +35,8 @@ app.env.veilarbregistreringScope=${VEILARBREGISTRERING_SCOPE}
 app.env.veilarbregistreringUrl=${VEILARBREGISTRERING_URL}
 app.env.kontoregisterScope=${KONTOREGISTER_PERSON_V1_SCOPE}
 app.env.kontoregisterUrl=${KONTOREGISTER_PERSON_V1_URL}
+app.env.aiaBackendUrl=${AIA_BACKEND_URL}
+app.env.aiaBackendScope=${AIA_BACKEND_SCOPE}
 
 # From config map "loginservice-idporten"
 app.env.loginserviceIdportenAudience=${LOGINSERVICE_IDPORTEN_AUDIENCE}

--- a/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
@@ -13,6 +13,8 @@ import no.nav.common.token_client.client.AzureAdOnBehalfOfTokenClient;
 import no.nav.common.types.identer.AktorId;
 import no.nav.common.types.identer.EksternBrukerId;
 import no.nav.common.types.identer.Fnr;
+import no.nav.veilarbperson.client.aiabackend.AiaBackendClient;
+import no.nav.veilarbperson.client.aiabackend.EndringIRegistreringsdataRequestDTO;
 import no.nav.veilarbperson.client.digdir.DigdirClient;
 import no.nav.veilarbperson.client.digdir.DigdirKontaktinfo;
 import no.nav.veilarbperson.client.kodeverk.KodeverkClient;
@@ -28,6 +30,7 @@ import no.nav.veilarbperson.client.veilarboppfolging.VeilarboppfolgingClient;
 import no.nav.veilarbperson.client.veilarbregistrering.VeilarbregistreringClient;
 import no.nav.veilarbperson.client.veilarbregistrering.VeilarbregistreringClientImpl;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.cloud.contract.wiremock.WireMockConfiguration;
 import org.springframework.cloud.contract.wiremock.WireMockConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -180,6 +183,22 @@ public class ClientTestConfig {
         return new VeilarboppfolgingClient() {
             @Override
             public UnderOppfolging hentUnderOppfolgingStatus(Fnr fnr) {
+                return null;
+            }
+
+            @Override
+            public HealthCheckResult checkHealth() {
+                return HealthCheckResult.healthy();
+            }
+        };
+    }
+
+    @Bean
+    public AiaBackendClient aiaBackendClient() {
+        return new AiaBackendClient() {
+            @NotNull
+            @Override
+            public Response hentEndringIRegistreringsdata(@NotNull EndringIRegistreringsdataRequestDTO endringIRegistreringsdataRequestDTO) {
                 return null;
             }
 


### PR DESCRIPTION
Etter samtale med Drago og Mathias ble vi enige om å gjøre backenden på lik som når man henter registreringsdataene. (altså egentlig bare sender data videre til frontenden). Dette gjør at det kun er en plass vi må endre dersom de utviderer mulighet til å endre data fra registreringen utover "Din situasjon", samt at man følger patterne som allerede er laget for registrering.