### PR TITLE
Logg infomelding dersom path/querystring matcher fnr-regex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <common.version>3.2023.05.25_12.58-6d52407f804a</common.version>
+        <common.version>3.2023.04.03_13.09-15bb53f1d80e</common.version>
         <tjenestespesifikasjoner.version>1.2019.09.25-00.21-49b69f0625e0</tjenestespesifikasjoner.version>
         <kotlin.version>1.9.0</kotlin.version>
     </properties>

--- a/src/main/java/no/nav/veilarbperson/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/no/nav/veilarbperson/config/CustomWebMvcConfigurer.java
@@ -1,0 +1,22 @@
+package no.nav.veilarbperson.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    private final FnrUsageLoggerInterceptor fnrUsageLoggerInterceptor;
+
+    @Autowired
+    public CustomWebMvcConfigurer(final FnrUsageLoggerInterceptor fnrUsageLoggerInterceptor) {
+        this.fnrUsageLoggerInterceptor = fnrUsageLoggerInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(fnrUsageLoggerInterceptor);
+    }
+}

--- a/src/main/java/no/nav/veilarbperson/config/CustomWebMvcConfigurer.java
+++ b/src/main/java/no/nav/veilarbperson/config/CustomWebMvcConfigurer.java
@@ -17,6 +17,6 @@ public class CustomWebMvcConfigurer implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(fnrUsageLoggerInterceptor);
+        registry.addInterceptor(fnrUsageLoggerInterceptor).addPathPatterns("/api/person", "/api/person/**", "/api/v2/person", "/api/v2/person/**");
     }
 }

--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -22,7 +22,7 @@ public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
     public boolean preHandle(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
         String requestURI = request.getRequestURI();
         String queryString = request.getQueryString();
-        String fnrPattern = "(^|\\W)\\d{11}(?=$|\\W)";
+        String fnrPattern = ".*\\b\\d{11}\\b.*";
 
         boolean hasFnrInRequestURI = StringUtils.notNullOrEmpty(requestURI) && requestURI.matches(fnrPattern);
         boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && requestURI.matches(fnrPattern);

--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -31,7 +31,7 @@ public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
             String consumerId = Optional.ofNullable(request.getHeader(NAV_CONSUMER_ID_HEADER_NAME)).orElse("unknown");
 
             MDC.put(MDC_ENDPOINT_KEY, requestURI);
-            log.debug("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
+            log.info("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
             MDC.remove(MDC_ENDPOINT_KEY);
         }
 

--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -25,7 +25,7 @@ public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
         String fnrPattern = ".*\\b\\d{11}\\b.*";
 
         boolean hasFnrInRequestURI = StringUtils.notNullOrEmpty(requestURI) && requestURI.matches(fnrPattern);
-        boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && requestURI.matches(fnrPattern);
+        boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && queryString.matches(fnrPattern);
 
         if (hasFnrInRequestURI || hasFnrInQueryString) {
             String consumerId = Optional.ofNullable(request.getHeader(NAV_CONSUMER_ID_HEADER_NAME)).orElse("unknown");

--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -2,16 +2,16 @@ package no.nav.veilarbperson.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
 import no.nav.common.utils.StringUtils;
+import no.nav.veilarbperson.utils.SecureLog;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-
 import java.util.Optional;
 
-@Slf4j
+import static no.nav.veilarbperson.utils.SecureLog.secureLog;
+
 @Component
 public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
 
@@ -31,7 +31,7 @@ public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
             String consumerId = Optional.ofNullable(request.getHeader(NAV_CONSUMER_ID_HEADER_NAME)).orElse("unknown");
 
             MDC.put(MDC_ENDPOINT_KEY, requestURI);
-            log.info("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
+            secureLog.info("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
             MDC.remove(MDC_ENDPOINT_KEY);
         }
 

--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -1,0 +1,40 @@
+package no.nav.veilarbperson.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.common.utils.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
+
+    private static final String NAV_CONSUMER_ID_HEADER_NAME = "Nav-Consumer-Id";
+    private static final String MDC_ENDPOINT_KEY = "endpoint";
+
+    @Override
+    public boolean preHandle(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
+        String requestURI = request.getRequestURI();
+        String queryString = request.getQueryString();
+        String fnrPattern = "(^|\\W)\\d{11}(?=$|\\W)";
+
+        boolean hasFnrInRequestURI = StringUtils.notNullOrEmpty(requestURI) && requestURI.matches(fnrPattern);
+        boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && requestURI.matches(fnrPattern);
+
+        if (hasFnrInRequestURI || hasFnrInQueryString) {
+            String consumerId = Optional.ofNullable(request.getHeader(NAV_CONSUMER_ID_HEADER_NAME)).orElse("unknown");
+
+            MDC.put(MDC_ENDPOINT_KEY, requestURI);
+            log.debug("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
+            MDC.remove(MDC_ENDPOINT_KEY);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/no/nav/veilarbperson/utils/SecureLog.java
+++ b/src/main/java/no/nav/veilarbperson/utils/SecureLog.java
@@ -1,0 +1,8 @@
+package no.nav.veilarbperson.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecureLog {
+    public static Logger secureLog = LoggerFactory.getLogger("SecureLog");
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,4 +3,5 @@
     <include resource="no/nav/common/log/logback-stdout-json.xml"/>
     <include resource="no/nav/common/log/logback-naudit.xml"/>
     <include resource="no/nav/common/log/logback-cxf.xml"/>
+    <include resource="no/nav/common/log/logback-securelogs.xml"/>
 </configuration>


### PR DESCRIPTION
Legger til funksjonalitet for å sjekke og eventuelt logge en beskjed dersom vi har konsumenter som går mot endepunkter i applikasjonen som inneholder fnr-parametre (path-params eller query-params). Sjekken er veldig enkel/dum og ser bare på henholdsvis URIen og query-stringen og sjekker om de inneholder en sekvens av elleve siffer.

Bruker `HandlerInterceptor`-konseptet til dette formålet slik at vi kan sette opp sjekken _en_ plass. Registrerer `FnrUsageLoggerInterceptor` i `InterceptorRegistry`-et til Spring slik at requester til appen blir sendt gjennom sjekken gitt i `preHandle`-metoden (se forøvrig: [Spring MVC HandlerInterceptor vs Filter: Key differences and use-cases](https://www.baeldung.com/spring-mvc-handlerinterceptor-vs-filter#key-differences-and-use-cases)).

Legger forøvrig selve URI-en på et logg-parameter vha. MDC, for å gjøre det enklere å filtrere/gruppere i Kibana.

Tanken er å bruke dette til å visualisere bruken av utdaterte endepunkter (aka. v1/v2) i arbeidet med å migrere over til v3:

![Screenshot 2023-10-16 at 14 08 53](https://github.com/navikt/veilarbperson/assets/111113539/32e93ab2-2594-403a-998c-b0fe79e1b30f)

---

En alternativ måte å gjøre dette på er å legge på logglinjer eksplisitt i hvert endepunkt (les: metode) i controller-ene hvor vi vet at vi har fnr-parametre. Da hadde vi sluppet en regex-sjekk siden vi kunne utledet dette fra konteksten i stedet. Men for å unngå duplisering valgte jeg å gjøre dette vha. `HandlerInterceptor`.