### PR TITLE
La være å logge endpoint til securelogs da det ikke dekker use-caset

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
+++ b/src/main/java/no/nav/veilarbperson/config/FnrUsageLoggerInterceptor.java
@@ -2,21 +2,15 @@ package no.nav.veilarbperson.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import no.nav.common.utils.StringUtils;
-import no.nav.veilarbperson.utils.SecureLog;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import java.util.Optional;
-
-import static no.nav.veilarbperson.utils.SecureLog.secureLog;
 
 @Component
+@Slf4j
 public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
-
-    private static final String NAV_CONSUMER_ID_HEADER_NAME = "Nav-Consumer-Id";
-    private static final String MDC_ENDPOINT_KEY = "endpoint";
 
     @Override
     public boolean preHandle(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull Object handler) {
@@ -28,11 +22,7 @@ public class FnrUsageLoggerInterceptor implements HandlerInterceptor {
         boolean hasFnrInQueryString = StringUtils.notNullOrEmpty(queryString) && queryString.matches(fnrPattern);
 
         if (hasFnrInRequestURI || hasFnrInQueryString) {
-            String consumerId = Optional.ofNullable(request.getHeader(NAV_CONSUMER_ID_HEADER_NAME)).orElse("unknown");
-
-            MDC.put(MDC_ENDPOINT_KEY, requestURI);
-            secureLog.info("Konsument {} forespurte endepunkt {} som matcher fnr-regex.", consumerId, requestURI);
-            MDC.remove(MDC_ENDPOINT_KEY);
+            log.info("Konsument forespurte endepunkt som matcher fnr-regex.");
         }
 
         return true;


### PR DESCRIPTION
SecureLogs-appenderen maskerer ikke fnr på samme måte som den vanlige appenderen, som gjør at vi ikke får mulighet til å gruppere på paths i Securelogs i Kibana.

Gjør det derfor veldig enkelt og bare logger en enkeltlinje (som vi kan bruke til å filtrere på relevante logglinjer) til vanlig logg (Applikasjonslogger). Vi kan uansett gruppere på konsument ( `x_consumerId`) da dette er et standard loggfelt som kommer med common-java-modules.