### PR TITLE
Add behandlingsnummer in PDL requests

### DIFF
--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -110,6 +110,7 @@ public class PdlClientImpl implements PdlClient {
                 .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
                 .header(AUTHORIZATION, createBearerToken(userToken))
                 .header("Tema", "GEN")
+                .header("behandlingsnummer", "B555")
                 .post(RequestBody.create(gqlRequest, MEDIA_TYPE_JSON));
 
         Request request = builder.build();


### PR DESCRIPTION
For each PDL request we should send behandlingsnummer, as this is requirement from PDL. Behandlingsnummer comes from Behandlingskatalog (https://behandlingskatalog.intern.nav.no/) and its different for each team and each behandling. We are using one that is defined here: [Oppfølging mot arbeid: Oversikten](https://behandlingskatalog.intern.nav.no/process/team/b8dac7f7-2ffb-4b85-a536-644487e53758/809966f6-118e-43ed-8625-d81d0c40ad37) 