### PR TITLE
Går mot gcp versjon av kodeverk

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -80,9 +80,9 @@ spec:
 
   env:
     - name: KODEVERK_URL
-      value: http://kodeverk.team-rocket.svc.nais.local
+      value: https://kodeverk-api.nav.no
     - name: KODEVERK_SCOPE
-      value: api://dev-fss.team-rocket.kodeverk/.default
+      value: api://dev-gcp.team-rocket.kodeverk-api/.default
     - name: KONTAKT_OG_RESERVASJONSREGISTERET_API_URL
       value: https://digdir-krr-proxy.intern.dev.nav.no
     - name: KONTAKT_OG_RESERVASJONSREGISTERET_SCOPE

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -77,9 +77,9 @@ spec:
 
   env:
     - name: KODEVERK_URL
-      value: http://kodeverk.team-rocket.svc.nais.local
+      value: https://kodeverk-api.nav.no
     - name: KODEVERK_SCOPE
-      value: api://prod-fss.team-rocket.kodeverk/.default
+      value: api://prod-gcp.team-rocket.kodeverk-api/.default
     - name: KONTAKT_OG_RESERVASJONSREGISTERET_API_URL
       value: https://digdir-krr-proxy.intern.nav.no
     - name: KONTAKT_OG_RESERVASJONSREGISTERET_SCOPE


### PR DESCRIPTION
rundt 1. april skrur team rocket av fss versjonen av kodeverk, vi må derfor bytte over til GCP kodeverk-api 