### PR TITLE
Hente siste opplysninger om arbeidssoeker og profilering  fra nytt arbeidssoekerregister

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -126,6 +126,11 @@ spec:
       value: https://www.intern.dev.nav.no/aia-backend
     - name: AIA_BACKEND_SCOPE
       value: api://dev-gcp.paw.paw-arbeidssoker-besvarelse/.default
+    - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
+      value: https://oppslag-arbeidssoekerregisteret.intern.dev.nav.no
+    - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
+      value: api://dev-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default
+
   envFrom:
     - configmap: pto-config
     - configmap: loginservice-idporten

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -120,6 +120,10 @@ spec:
       value: https://www.nav.no/aia-backend
     - name: AIA_BACKEND_SCOPE
       value: api://prod-gcp.paw.paw-arbeidssoker-besvarelse/.default
+    - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
+      value: https://oppslag-arbeidssoekerregisteret.intern.nav.no
+    - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
+      value: api://prod-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default
   envFrom:
     - configmap: pto-config
     - configmap: loginservice-idporten

--- a/src/main/java/no/nav/veilarbperson/client/oppslagArbeidssoekerregisteret/OppslagArbeidssoekerregisteretClient.kt
+++ b/src/main/java/no/nav/veilarbperson/client/oppslagArbeidssoekerregisteret/OppslagArbeidssoekerregisteretClient.kt
@@ -1,0 +1,16 @@
+package no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret
+
+import no.nav.common.health.HealthCheck
+import java.util.*
+
+interface OppslagArbeidssoekerregisteretClient: HealthCheck {
+
+    fun hentArbeidssokerPerioder(identitetsnummer: String): List<ArbeidssokerperiodeResponse>?
+
+    fun hentOpplysningerOmArbeidssoeker(
+        identitetsnummer: String,
+        periodeId: UUID
+    ): List<OpplysningerOmArbeidssoekerResponse>?
+
+    fun hentProfilering(identitetsnummer: String, periodeId: UUID): List<ProfileringResponse>?
+}

--- a/src/main/java/no/nav/veilarbperson/client/oppslagArbeidssoekerregisteret/OppslagArbeidssoekerregisteretClientImpl.kt
+++ b/src/main/java/no/nav/veilarbperson/client/oppslagArbeidssoekerregisteret/OppslagArbeidssoekerregisteretClientImpl.kt
@@ -1,0 +1,191 @@
+package no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret
+
+import no.nav.common.health.HealthCheckResult
+import no.nav.common.health.HealthCheckUtils
+import no.nav.common.rest.client.RestClient
+import no.nav.common.rest.client.RestUtils
+import no.nav.common.utils.UrlUtils
+import no.nav.veilarbperson.utils.deserializeJsonOrThrow
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import java.time.ZonedDateTime
+import java.util.*
+import java.util.function.Supplier
+
+const val NAV_CONSUMER_ID = "Nav-Consumer-Id"
+
+class OppslagArbeidssoekerregisteretClientImpl(
+    private val url: String,
+    private val machineToMachinetokenSupplier: Supplier<String>,
+    private val consumerId: String
+): OppslagArbeidssoekerregisteretClient {
+
+    private val client: OkHttpClient = RestClient.baseClient()
+
+    override fun hentArbeidssokerPerioder(identitetsnummer: String): List<ArbeidssokerperiodeResponse>? {
+        val request: Request = Request.Builder()
+            .url(UrlUtils.joinPaths(url, "/api/v1/veileder/arbeidssoekerperioder"))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ${machineToMachinetokenSupplier.get()}")
+            .header(NAV_CONSUMER_ID, consumerId)
+            .post(RestUtils.toJsonRequestBody(ArbeidssoekerperiodeRequest(identitetsnummer)))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (response.code == HttpStatus.NOT_FOUND.value()) {
+                return null
+            }
+
+            RestUtils.throwIfNotSuccessful(response)
+
+            return response.deserializeJsonOrThrow()
+        }
+    }
+
+    override fun hentOpplysningerOmArbeidssoeker(
+        identitetsnummer: String,
+        periodeId: UUID
+    ): List<OpplysningerOmArbeidssoekerResponse>? {
+        val request: Request = Request.Builder()
+            .url(UrlUtils.joinPaths(url, "/api/v1/veileder/opplysninger-om-arbeidssoeker"))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ${machineToMachinetokenSupplier.get()}")
+            .header(NAV_CONSUMER_ID, consumerId)
+            .post(RestUtils.toJsonRequestBody(OpplysningerOmArbeidssoekerRequest(identitetsnummer, periodeId)))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (response.code == HttpStatus.NOT_FOUND.value()) {
+                return null
+            }
+
+            RestUtils.throwIfNotSuccessful(response)
+
+            return response.deserializeJsonOrThrow()
+        }
+    }
+
+    override fun hentProfilering(identitetsnummer: String, periodeId: UUID): List<ProfileringResponse>? {
+        val request: Request = Request.Builder()
+            .url(UrlUtils.joinPaths(url, "/api/v1/veileder/profilering"))
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ${machineToMachinetokenSupplier.get()}")
+            .header(NAV_CONSUMER_ID, consumerId)
+            .post(RestUtils.toJsonRequestBody(ProfileringRequest(identitetsnummer, periodeId)))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (response.code == HttpStatus.NOT_FOUND.value()) {
+                return null
+            }
+
+            RestUtils.throwIfNotSuccessful(response)
+
+            return response.deserializeJsonOrThrow()
+        }
+    }
+
+    override fun checkHealth(): HealthCheckResult {
+        return HealthCheckUtils.pingUrl(UrlUtils.joinPaths(url, "/internal/isReady"), client)
+    }
+}
+
+// Arbeidssøkerperioder typer
+data class ArbeidssoekerperiodeRequest(val identitetsnummer: String)
+
+data class ArbeidssokerperiodeResponse(
+    val periodeId: UUID,
+    val startet: MetadataResponse,
+    val avsluttet: MetadataResponse?
+)
+
+// Opplysninger om arbeidssøker typer
+data class OpplysningerOmArbeidssoekerRequest(val identitetsnummer: String, val periodeId: UUID)
+
+data class OpplysningerOmArbeidssoekerResponse(
+    val opplysningerOmArbeidssoekerId: UUID,
+    val periodeId: UUID,
+    val sendtInnAv: MetadataResponse,
+    val utdanning: UtdanningResponse?,
+    val helse: HelseResponse?,
+    val annet: AnnetResponse?,
+    val jobbsituasjon: List<BeskrivelseMedDetaljerResponse>
+)
+
+data class BeskrivelseMedDetaljerResponse(
+    val beskrivelse: JobbSituasjonBeskrivelseResponse,
+    val detaljer: Map<String, String>
+)
+
+enum class JobbSituasjonBeskrivelseResponse {
+    UKJENT_VERDI,
+    UDEFINERT,
+    HAR_SAGT_OPP,
+    HAR_BLITT_SAGT_OPP,
+    ER_PERMITTERT,
+    ALDRI_HATT_JOBB,
+    IKKE_VAERT_I_JOBB_SISTE_2_AAR,
+    AKKURAT_FULLFORT_UTDANNING,
+    VIL_BYTTE_JOBB,
+    USIKKER_JOBBSITUASJON,
+    MIDLERTIDIG_JOBB,
+    DELTIDSJOBB_VIL_MER,
+    NY_JOBB,
+    KONKURS,
+    ANNET
+}
+
+data class AnnetResponse(
+    val andreForholdHindrerArbeid: JaNeiVetIkke?
+)
+
+data class HelseResponse(
+    val helsetilstandHindrerArbeid: JaNeiVetIkke
+)
+
+data class UtdanningResponse(
+    val nus: String,    // NUS = Standard for utdanningsgruppering (https://www.ssb.no/klass/klassifikasjoner/36/)
+    val bestaatt: JaNeiVetIkke?,
+    val godkjent: JaNeiVetIkke?
+)
+
+// Profilering typer
+data class ProfileringRequest(val identitetsnummer: String, val periodeId: UUID)
+
+data class ProfileringResponse(
+    val profileringId: UUID,
+    val periodeId: UUID,
+    val opplysningerOmArbeidssoekerId: UUID,
+    val sendtInnAv: MetadataResponse,
+    val profilertTil: ProfilertTil,
+    val jobbetSammenhengendeSeksAvTolvSisteManeder: Boolean?,
+    val alder: Int?
+)
+
+enum class ProfilertTil {
+    UKJENT_VERDI,
+    UDEFINERT,
+    ANTATT_GODE_MULIGHETER,
+    ANTATT_BEHOV_FOR_VEILEDNING,
+    OPPGITT_HINDRINGER
+}
+
+// Felles typer
+enum class JaNeiVetIkke {
+    JA, NEI, VET_IKKE
+}
+
+data class MetadataResponse(
+    val tidspunkt: ZonedDateTime,
+    val utfoertAv: BrukerResponse,
+    val kilde: String,
+    val aarsak: String
+)
+
+data class BrukerResponse(
+    val type: BrukerType,
+    val id: String?
+)
+
+enum class BrukerType {
+    UKJENT_VERDI, UDEFINERT, VEILEDER, SYSTEM, SLUTTBRUKER
+}

--- a/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/ClientConfig.java
@@ -27,6 +27,8 @@ import no.nav.veilarbperson.client.kontoregister.KontoregisterClient;
 import no.nav.veilarbperson.client.kontoregister.KontoregisterClientImpl;
 import no.nav.veilarbperson.client.nom.SkjermetClient;
 import no.nav.veilarbperson.client.nom.SkjermetClientImpl;
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OppslagArbeidssoekerregisteretClient;
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OppslagArbeidssoekerregisteretClientImpl;
 import no.nav.veilarbperson.client.pam.PamClient;
 import no.nav.veilarbperson.client.pam.PamClientImpl;
 import no.nav.veilarbperson.client.pdl.PdlClient;
@@ -38,6 +40,10 @@ import no.nav.veilarbperson.client.veilarbregistrering.VeilarbregistreringClient
 import no.nav.veilarbperson.service.AuthService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Supplier;
+
+import static no.nav.veilarbperson.config.ApplicationConfig.APPLICATION_NAME;
 
 
 @Slf4j
@@ -112,6 +118,18 @@ public class ClientConfig {
         return new VeilarbregistreringClientImpl(RestClient.baseClient(),
                 properties.getVeilarbregistreringUrl(),
                 () -> aadMachineToMachineTokenClient.createMachineToMachineToken(properties.getVeilarbregistreringScope()));
+    }
+
+    @Bean
+    public OppslagArbeidssoekerregisteretClient oppslagArbeidssoekerregisteretClient(
+            EnvironmentProperties properties,
+            AzureAdMachineToMachineTokenClient aadMachineToMachineTokenClient
+    ) {
+        return new OppslagArbeidssoekerregisteretClientImpl(
+                properties.getOppslagArbeidssoekerregisteretUrl(),
+                () -> aadMachineToMachineTokenClient.createMachineToMachineToken(properties.getOppslagArbeidssoekerregisteretScope()),
+                APPLICATION_NAME
+        );
     }
 
 

--- a/src/main/java/no/nav/veilarbperson/config/EnvironmentProperties.java
+++ b/src/main/java/no/nav/veilarbperson/config/EnvironmentProperties.java
@@ -38,4 +38,6 @@ public class EnvironmentProperties {
     private String kontoregisterUrl;
     private String aiaBackendUrl;
     private String aiaBackendScope;
+    private String oppslagArbeidssoekerregisteretUrl;
+    private String oppslagArbeidssoekerregisteretScope;
 }

--- a/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
@@ -7,10 +7,7 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.veilarbperson.client.regoppslag.RegoppslagClient;
 import no.nav.veilarbperson.client.regoppslag.RegoppslagResponseDTO;
 import no.nav.veilarbperson.domain.*;
-import no.nav.veilarbperson.service.AuthService;
-import no.nav.veilarbperson.service.CvJobbprofilService;
-import no.nav.veilarbperson.service.PersonV2Service;
-import no.nav.veilarbperson.service.RegistreringService;
+import no.nav.veilarbperson.service.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -30,6 +27,8 @@ public class PersonV3Controller {
     private final CvJobbprofilService cvJobbprofilService;
 
     private final RegistreringService registreringService;
+
+    private final OppslagArbeidssoekerregisteretService oppslagArbeidssoekerregisteretService;
 
     @PostMapping("/hent-person")
     @Operation(summary = "Henter informasjon om en person fra PDL")
@@ -122,6 +121,14 @@ public class PersonV3Controller {
         authService.stoppHvisEksternBruker();
         authService.sjekkLesetilgang(personRequest.getFnr());
         return regoppslagClient.hentPostadresse(personRequest.getFnr());
+    }
+
+    @PostMapping("/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering")
+    @Operation(summary = "Henter svarene fra den siste arbeidssøkerregistrering til en person i en aktiv arbeidssøkerperiode")
+    public OpplysningerOmArbeidssoekerMedProfilering hentSisteOpplysningerOmArbeidssoerkerOgProfilering(@RequestBody PersonRequest personRequest) {
+        authService.stoppHvisEksternBruker();
+        authService.sjekkLesetilgang(personRequest.getFnr());
+        return oppslagArbeidssoekerregisteretService.hentSisteOpplysningerOmArbeidssoekerMedProfilering(personRequest.getFnr());
     }
 
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {

--- a/src/main/java/no/nav/veilarbperson/domain/Arbeidssoekerregister.kt
+++ b/src/main/java/no/nav/veilarbperson/domain/Arbeidssoekerregister.kt
@@ -1,0 +1,29 @@
+package no.nav.veilarbperson.domain
+
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OpplysningerOmArbeidssoekerResponse
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.ProfileringResponse
+
+data class OpplysningerOmArbeidssoekerMedProfilering(
+    val opplysningerOmArbeidssoeker: OpplysningerOmArbeidssoekerResponse? = null,
+    val profilering: ProfileringResponse ? = null
+)
+
+
+
+fun OpplysningerOmArbeidssoekerResponse.mapToOpplyasningerOmArbeidssoekerMedNuskode(): OpplysningerOmArbeidssoekerResponse {
+    val utdanning = this.utdanning?.copy(nus = mapNuskodeTilUtdanningsnivaa(this.utdanning.nus))
+    return this.copy(utdanning = utdanning)
+}
+
+
+fun mapNuskodeTilUtdanningsnivaa(nusKode: String?): String {
+    return when (nusKode) {
+        "0" -> "INGEN_UTDANNING"
+        "2" -> "GRUNNSKOLE"
+        "3" -> "VIDEREGAENDE_GRUNNUTDANNING"
+        "4" -> "VIDEREGAENDE_FAGBREV_SVENNEBREV"
+        "6" -> "HOYERE_UTDANNING_1_TIL_4"
+        "7" -> "HOYERE_UTDANNING_5_ELLER_MER"
+        else -> "INGEN_SVAR"
+    }
+}

--- a/src/main/java/no/nav/veilarbperson/service/OppslagArbeidssoekerregisteretService.kt
+++ b/src/main/java/no/nav/veilarbperson/service/OppslagArbeidssoekerregisteretService.kt
@@ -1,0 +1,41 @@
+package no.nav.veilarbperson.service
+
+import no.nav.common.types.identer.Fnr
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OppslagArbeidssoekerregisteretClient
+import no.nav.veilarbperson.domain.OpplysningerOmArbeidssoekerMedProfilering
+import no.nav.veilarbperson.domain.mapToOpplyasningerOmArbeidssoekerMedNuskode
+import org.springframework.http.HttpStatusCode
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class OppslagArbeidssoekerregisteretService(
+    private val oppslagArbeidssoekerregisteretClient: OppslagArbeidssoekerregisteretClient
+) {
+    fun hentSisteOpplysningerOmArbeidssoekerMedProfilering(fnr: Fnr): OpplysningerOmArbeidssoekerMedProfilering? {
+        val aktivArbeidssoekerperiode = oppslagArbeidssoekerregisteretClient.hentArbeidssokerPerioder(fnr.get())
+            ?.find { it.avsluttet == null }
+
+        if (aktivArbeidssoekerperiode == null) {
+            throw ResponseStatusException(HttpStatusCode.valueOf(204),"Fant ingen aktiv arbeidssøkerperiode for bruker")
+        }
+
+        val sisteOpplysningerOmArbeidssoeker = oppslagArbeidssoekerregisteretClient.hentOpplysningerOmArbeidssoeker(
+            fnr.get(),
+            aktivArbeidssoekerperiode.periodeId
+        )?.maxByOrNull {
+            it.sendtInnAv.tidspunkt
+        }
+
+        if (sisteOpplysningerOmArbeidssoeker == null) {
+            throw ResponseStatusException(HttpStatusCode.valueOf(204),"Fant ingen opplysninger om arbeidssoeker")
+        }
+
+        val sisteProfilering =
+            oppslagArbeidssoekerregisteretClient.hentProfilering(fnr.get(), aktivArbeidssoekerperiode.periodeId)
+                ?.filter { it.opplysningerOmArbeidssoekerId == sisteOpplysningerOmArbeidssoeker.opplysningerOmArbeidssoekerId }
+                ?.maxByOrNull { it.sendtInnAv.tidspunkt }
+
+        return OpplysningerOmArbeidssoekerMedProfilering(sisteOpplysningerOmArbeidssoeker.mapToOpplyasningerOmArbeidssoekerMedNuskode(), sisteProfilering)
+    }
+}

--- a/src/main/java/no/nav/veilarbperson/utils/JsonUtils.kt
+++ b/src/main/java/no/nav/veilarbperson/utils/JsonUtils.kt
@@ -2,6 +2,7 @@ package no.nav.veilarbperson.utils
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.common.rest.client.RestUtils
 import okhttp3.Response
 
@@ -12,7 +13,10 @@ object JsonUtils {
 
 inline fun <reified T> Response.deserializeJson(): T? {
     return RestUtils.getBodyStr(this)
-        .map { JsonUtils.objectMapper.readValue(it, T::class.java) }
+        .map {
+            val result: T = JsonUtils.objectMapper.readValue(it)
+            result
+        }
         .orElse(null)
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,6 +36,9 @@ app.env.kontoregisterScope=${KONTOREGISTER_PERSON_V1_SCOPE}
 app.env.kontoregisterUrl=${KONTOREGISTER_PERSON_V1_URL}
 app.env.aiaBackendUrl=${AIA_BACKEND_URL}
 app.env.aiaBackendScope=${AIA_BACKEND_SCOPE}
+app.env.oppslagArbeidssoekerregisteretScope=${OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE}
+app.env.oppslagArbeidssoekerregisteretUrl=${OPPSLAG_ARBEIDSSOEKERREGISTERET_URL}
+
 
 # From config map "loginservice-idporten"
 app.env.loginserviceIdportenAudience=${LOGINSERVICE_IDPORTEN_AUDIENCE}

--- a/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
@@ -21,6 +21,8 @@ import no.nav.veilarbperson.client.kontoregister.HentKontoRequestDTO;
 import no.nav.veilarbperson.client.kontoregister.HentKontoResponseDTO;
 import no.nav.veilarbperson.client.kontoregister.KontoregisterClient;
 import no.nav.veilarbperson.client.nom.SkjermetClient;
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OppslagArbeidssoekerregisteretClient;
+import no.nav.veilarbperson.client.oppslagArbeidssoekerregisteret.OppslagArbeidssoekerregisteretClientImpl;
 import no.nav.veilarbperson.client.pam.PamClient;
 import no.nav.veilarbperson.client.pdl.HentPerson;
 import no.nav.veilarbperson.client.pdl.PdlClient;
@@ -274,6 +276,12 @@ public class ClientTestConfig {
     public VeilarbregistreringClient veilarbregistreringClient() {
         return new VeilarbregistreringClientImpl(
                 RestClient.baseClient(), "http://localhost:" + WIREMOCK_PORT, () -> "");
+    }
+
+    @Bean
+    public OppslagArbeidssoekerregisteretClient oppslagArbeidssoekerregisteretClient() {
+        return new OppslagArbeidssoekerregisteretClientImpl(
+                "http://localhost:" + WIREMOCK_PORT, () -> "", "veilarbperson");
     }
 
     @Bean

--- a/src/test/java/no/nav/veilarbperson/config/ServiceTestConfig.java
+++ b/src/test/java/no/nav/veilarbperson/config/ServiceTestConfig.java
@@ -12,5 +12,6 @@ import org.springframework.context.annotation.Import;
 		PersonV2Service.class,
 		CvJobbprofilService.class,
 		RegistreringService.class,
+		OppslagArbeidssoekerregisteretService.class
 })
 public class ServiceTestConfig {}

--- a/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
@@ -2,6 +2,7 @@ package no.nav.veilarbperson.controller;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import no.nav.common.json.JsonUtils;
+import no.nav.common.types.identer.Fnr;
 import no.nav.poao_tilgang.poao_tilgang_test_core.NavAnsatt;
 import no.nav.poao_tilgang.poao_tilgang_test_core.NavContext;
 import no.nav.poao_tilgang.poao_tilgang_test_core.PrivatBruker;
@@ -64,7 +65,7 @@ public class PersonV3ControllerTest {
                 .perform(
                         post("/api/v3/person/hent-registrering")
                                 .contentType(APPLICATION_JSON)
-                                .content("{\"fnr\":\""+ fnr +"\"}")
+                                .content("{\"fnr\":\"" + fnr + "\"}")
                                 .header("test_ident", navAnsatt.getNavIdent())
                                 .header("test_ident_type", "INTERN")
                 )
@@ -88,7 +89,7 @@ public class PersonV3ControllerTest {
                 .perform(
                         post("/api/v3/person/hent-registrering")
                                 .contentType(APPLICATION_JSON)
-                                .content("{\"fnr\":\""+ fnr +"\"}")
+                                .content("{\"fnr\":\"" + fnr + "\"}")
                                 .header("test_ident", navAnsatt.getNavIdent())
                                 .header("test_ident_type", "INTERN")
                 )
@@ -137,6 +138,318 @@ public class PersonV3ControllerTest {
                 )
                 .andExpect(content().json(expectedJson))
                 .andExpect(status().is(200));
+    }
+
+    @Test
+    void returnerer_opplysninger_om_arbeidssoeker_med_profilering_paa_bruker() throws Exception {
+        PrivatBruker ny = navContext.getPrivatBrukere().ny();
+        NavAnsatt navAnsatt = navContext.getNavAnsatt().nyFor(ny);
+        String fnr = ny.getNorskIdent();
+
+        String expectedJsonArbeidssoekerPeriode = """
+                    [
+                      {
+                        "periodeId": "ea0ad984-8b99-4fff-afd6-07737ab19d16",
+                        "startet": {
+                          "tidspunkt": "2024-04-23T13:04:40.739Z",
+                          "utfoertAv": {
+                            "type": "SLUTTBRUKER"
+                          },
+                          "kilde": "europe-north1-docker.pkg.dev/nais-management-233d/paw/paw-arbeidssokerregisteret-api-inngang:24.04.23.118-1",
+                          "aarsak": "Er over 18 år, er bosatt i Norge i hendhold Folkeregisterloven"
+                        },
+                        "avsluttet": null
+                      }
+                    ]
+                """.trim();
+
+        String expectedJsonOpplysningerOmArbeidssoeker = "[" +
+                "  {" +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-23T13:22:58.089Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SLUTTBRUKER\"," +
+                "        \"id\": \"Z123456\"" +
+                "      }," +
+                "      \"kilde\": \"paw-arbeidssoekerregisteret-inngang\"," +
+                "      \"aarsak\": \"opplysning om arbeidssøker sendt inn\"" +
+                "    }," +
+                "    \"jobbsituasjon\": [" +
+                "      {" +
+                "        \"beskrivelse\": \"ALDRI_HATT_JOBB\"," +
+                "        \"detaljer\": { \"prosent\":  \"25\" }" +
+                "      }," +
+                "      {" +
+                "        \"beskrivelse\": \"ER_PERMITTERT\"," +
+                "        \"detaljer\": { \"prosent\":  \"75\" }" +
+                "      }" +
+                "    ]," +
+                "    \"utdanning\": {" +
+                "      \"nus\": \"3\"," +
+                "      \"bestaatt\": \"JA\"," +
+                "      \"godkjent\": \"JA\"" +
+                "    }," +
+                "    \"helse\": {" +
+                "      \"helsetilstandHindrerArbeid\": \"NEI\"" +
+                "    }," +
+                "    \"annet\": {" +
+                "      \"andreForholdHindrerArbeid\": \"NEI\"" +
+                "    }" +
+                "  }" +
+                "]";
+
+        String expectedJsonProfilering = "[" +
+                "  {" +
+                "    \"profileringId\": \"7c9a2feb-0b31-4101-825a-0c4a3d465e01\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-25T08:19:53.612Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SYSTEM\"" +
+                "      }," +
+                "      \"kilde\": \"null-null\"," +
+                "      \"aarsak\": \"opplysninger-mottatt\"" +
+                "    }," +
+                "    \"profilertTil\": \"OPPGITT_HINDRINGER\"," +
+                "    \"jobbetSammenhengendeSeksAvTolvSisteManeder\": false," +
+                "    \"alder\": 33" +
+                "  }" +
+                "]";
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/arbeidssoekerperioder"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonArbeidssoekerPeriode)));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/opplysninger-om-arbeidssoeker"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonOpplysningerOmArbeidssoeker)));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/profilering"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonProfilering)));
+
+        String expectedJson = "{\"opplysningerOmArbeidssoeker\":{\"opplysningerOmArbeidssoekerId\":\"913161a3-dde9-4448-abf8-2a01a043f8cd\",\"periodeId\":\"ea0ad984-8b99-4fff-afd6-07737ab19d16\",\"sendtInnAv\":{\"tidspunkt\":\"2024-04-23T13:22:58.089Z\",\"utfoertAv\":{\"type\":\"SLUTTBRUKER\",\"id\":\"Z123456\"},\"kilde\":\"paw-arbeidssoekerregisteret-inngang\",\"aarsak\":\"opplysning om arbeidssøker sendt inn\"},\"utdanning\":{\"nus\":\"VIDEREGAENDE_GRUNNUTDANNING\",\"bestaatt\":\"JA\",\"godkjent\":\"JA\"},\"helse\":{\"helsetilstandHindrerArbeid\":\"NEI\"},\"annet\":{\"andreForholdHindrerArbeid\":\"NEI\"},\"jobbsituasjon\":[{\"beskrivelse\":\"ALDRI_HATT_JOBB\",\"detaljer\":{\"prosent\":\"25\"}},{\"beskrivelse\":\"ER_PERMITTERT\",\"detaljer\":{\"prosent\":\"75\"}}]},\"profilering\":{\"profileringId\":\"7c9a2feb-0b31-4101-825a-0c4a3d465e01\",\"periodeId\":\"ea0ad984-8b99-4fff-afd6-07737ab19d16\",\"opplysningerOmArbeidssoekerId\":\"913161a3-dde9-4448-abf8-2a01a043f8cd\",\"sendtInnAv\":{\"tidspunkt\":\"2024-04-25T08:19:53.612Z\",\"utfoertAv\":{\"type\":\"SYSTEM\",\"id\":null},\"kilde\":\"null-null\",\"aarsak\":\"opplysninger-mottatt\"},\"profilertTil\":\"OPPGITT_HINDRINGER\",\"jobbetSammenhengendeSeksAvTolvSisteManeder\":false,\"alder\":33}}";
+
+        mockMvc
+                .perform(
+                        post("/api/v3/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering")
+                                .contentType(APPLICATION_JSON)
+                                .content(JsonUtils.toJson(new PersonFraPdlRequest(Fnr.of(fnr), null)))
+                                .header("test_ident", navAnsatt.getNavIdent())
+                                .header("test_ident_type", "INTERN")
+                )
+                .andExpect(status().is(200))
+                .andExpect(content().json(expectedJson));
+
+    }
+
+    @Test
+    void returnerer_null_dersom_person_ikke_har_aktiv_arbeidssoekerperiode() throws Exception {
+        PrivatBruker ny = navContext.getPrivatBrukere().ny();
+        NavAnsatt navAnsatt = navContext.getNavAnsatt().nyFor(ny);
+        String fnr = ny.getNorskIdent();
+
+        String expectedJsonOpplysningerOmArbeidssoeker = "[" +
+                "  {" +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-23T13:22:58.089Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SLUTTBRUKER\"" +
+                "      }," +
+                "      \"kilde\": \"paw-arbeidssoekerregisteret-inngang\"," +
+                "      \"aarsak\": \"opplysning om arbeidssøker sendt inn\"" +
+                "    }," +
+                "    \"jobbsituasjon\": [" +
+                "      {" +
+                "        \"beskrivelse\": \"ALDRI_HATT_JOBB\"," +
+                "        \"detaljer\": { \"prosent\":  \"25\" }" +
+                "      }," +
+                "      {" +
+                "        \"beskrivelse\": \"ER_PERMITTERT\"," +
+                "        \"detaljer\": { \"prosent\":  \"75\" }" +
+                "      }" +
+                "    ]," +
+                "    \"utdanning\": {" +
+                "      \"nus\": \"3\"," +
+                "      \"bestaatt\": \"JA\"," +
+                "      \"godkjent\": \"JA\"" +
+                "    }," +
+                "    \"helse\": {" +
+                "      \"helsetilstandHindrerArbeid\": \"NEI\"" +
+                "    }," +
+                "    \"annet\": {" +
+                "      \"andreForholdHindrerArbeid\": \"NEI\"" +
+                "    }" +
+                "  }" +
+                "]";
+
+        String expectedJsonProfilering = "[" +
+                "  {" +
+                "    \"profileringId\": \"7c9a2feb-0b31-4101-825a-0c4a3d465e01\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-25T08:19:53.612Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SYSTEM\"" +
+                "      }," +
+                "      \"kilde\": \"null-null\"," +
+                "      \"aarsak\": \"opplysninger-mottatt\"" +
+                "    }," +
+                "    \"profilertTil\": \"OPPGITT_HINDRINGER\"," +
+                "    \"jobbetSammenhengendeSeksAvTolvSisteManeder\": false," +
+                "    \"alder\": 33" +
+                "  }" +
+                "]";
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/arbeidssoekerperioder"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody("[]")));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/opplysninger-om-arbeidssoeker"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonOpplysningerOmArbeidssoeker)));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/profilering"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonProfilering)));
+
+        mockMvc
+                .perform(
+                        post("/api/v3/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering")
+                                .contentType(APPLICATION_JSON)
+                                .content(JsonUtils.toJson(new PersonFraPdlRequest(Fnr.of(fnr), null)))
+                                .header("test_ident", navAnsatt.getNavIdent())
+                                .header("test_ident_type", "INTERN")
+                )
+                .andExpect(status().is(204))
+                .andExpect(content().string(""));
+
+    }
+
+    @Test
+    void returnerer_null_dersom_person_kun_har_avsluttede_arbeidssoekerperioder() throws Exception {
+        PrivatBruker ny = navContext.getPrivatBrukere().ny();
+        NavAnsatt navAnsatt = navContext.getNavAnsatt().nyFor(ny);
+        String fnr = ny.getNorskIdent();
+
+        String expectedJsonArbeidssoekerPeriode = """
+                    [
+                      {
+                        "periodeId": "ea0ad984-8b99-4fff-afd6-07737ab19d16",
+                        "startet": {
+                          "tidspunkt": "2024-04-23T13:04:40.739Z",
+                          "utfoertAv": {
+                            "type": "SLUTTBRUKER"
+                          },
+                          "kilde": "europe-north1-docker.pkg.dev/nais-management-233d/paw/paw-arbeidssokerregisteret-api-inngang:24.04.23.118-1",
+                          "aarsak": "Er over 18 år, er bosatt i Norge i hendhold Folkeregisterloven"
+                        },
+                        "avsluttet": {
+                          "tidspunkt": "2024-05-23T13:04:40.739Z",
+                          "utfoertAv": {
+                            "type": "VEILEDER",
+                            "id": "Z123456"
+                          },
+                          "kilde": "europe-north1-docker.pkg.dev/nais-management-233d/paw/paw-arbeidssokerregisteret-api-inngang:24.04.23.118-1",
+                          "aarsak": "Er over 18 år, er bosatt i Norge i hendhold Folkeregisterloven"
+                        }
+                      }
+                    ]
+                """.trim();
+
+        String expectedJsonOpplysningerOmArbeidssoeker = "[" +
+                "  {" +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-23T13:22:58.089Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SLUTTBRUKER\"" +
+                "      }," +
+                "      \"kilde\": \"paw-arbeidssoekerregisteret-inngang\"," +
+                "      \"aarsak\": \"opplysning om arbeidssøker sendt inn\"" +
+                "    }," +
+                "    \"jobbsituasjon\": [" +
+                "      {" +
+                "        \"beskrivelse\": \"ALDRI_HATT_JOBB\"," +
+                "        \"detaljer\": { \"prosent\":  \"25\" }" +
+                "      }," +
+                "      {" +
+                "        \"beskrivelse\": \"ER_PERMITTERT\"," +
+                "        \"detaljer\": { \"prosent\":  \"75\" }" +
+                "      }" +
+                "    ]," +
+                "    \"utdanning\": {" +
+                "      \"nus\": \"3\"," +
+                "      \"bestaatt\": \"JA\"," +
+                "      \"godkjent\": \"JA\"" +
+                "    }," +
+                "    \"helse\": {" +
+                "      \"helsetilstandHindrerArbeid\": \"NEI\"" +
+                "    }," +
+                "    \"annet\": {" +
+                "      \"andreForholdHindrerArbeid\": \"NEI\"" +
+                "    }" +
+                "  }" +
+                "]";
+
+        String expectedJsonProfilering = "[" +
+                "  {" +
+                "    \"profileringId\": \"7c9a2feb-0b31-4101-825a-0c4a3d465e01\"," +
+                "    \"periodeId\": \"ea0ad984-8b99-4fff-afd6-07737ab19d16\"," +
+                "    \"opplysningerOmArbeidssoekerId\": \"913161a3-dde9-4448-abf8-2a01a043f8cd\"," +
+                "    \"sendtInnAv\": {" +
+                "      \"tidspunkt\": \"2024-04-25T08:19:53.612Z\"," +
+                "      \"utfoertAv\": {" +
+                "        \"type\": \"SYSTEM\"" +
+                "      }," +
+                "      \"kilde\": \"null-null\"," +
+                "      \"aarsak\": \"opplysninger-mottatt\"" +
+                "    }," +
+                "    \"profilertTil\": \"OPPGITT_HINDRINGER\"," +
+                "    \"jobbetSammenhengendeSeksAvTolvSisteManeder\": false," +
+                "    \"alder\": 33" +
+                "  }" +
+                "]";
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/arbeidssoekerperioder"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonArbeidssoekerPeriode)));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/opplysninger-om-arbeidssoeker"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonOpplysningerOmArbeidssoeker)));
+
+        stubFor(WireMock.post(urlEqualTo("/api/v1/veileder/profilering"))
+                .willReturn(ok()
+                        .withHeader("Nav-Consumer-Id", "veilarbperson")
+                        .withBody(expectedJsonProfilering)));
+
+        mockMvc
+                .perform(
+                        post("/api/v3/person/hent-siste-opplysninger-om-arbeidssoeker-med-profilering")
+                                .contentType(APPLICATION_JSON)
+                                .content(JsonUtils.toJson(new PersonFraPdlRequest(Fnr.of(fnr), null)))
+                                .header("test_ident", navAnsatt.getNavIdent())
+                                .header("test_ident_type", "INTERN")
+                )
+                .andExpect(status().is(204))
+                .andExpect(content().string(""));
+
     }
 
 }


### PR DESCRIPTION
Fordi flere av våre apper kun er ute etter siste opplysninger og profilering på bruker (aktive) så har vi satt inn et endepunkt i veilarbperson slik at alle må deale med å først spørre etter arbeidssoeker periode for så å kunne hente ut opplysninger og så hente ut profilering. Enkelere da at alle våre apper kun spør basert på fnr og får tilbake de siste gjeldene opplysningene fra det nye arbeidssoekerregisteret. (konsumenter vil bl.a bli veilarbvedtaksstotte og veilarbdetaljerfs)