### PR TITLE
kommenterer ut norg2-selftest fordi den nå feiler før vi kommer over på gcp

### DIFF
--- a/src/main/java/no/nav/veilarbperson/config/SelftTestConfig.java
+++ b/src/main/java/no/nav/veilarbperson/config/SelftTestConfig.java
@@ -34,7 +34,7 @@ public class SelftTestConfig {
                 new SelfTestCheck("AktorOppslagClient", true, aktorOppslagClient),
                 new SelfTestCheck("Digitalkontakinformasjon (DIGDIR)", false, digdirClient),
                 new SelfTestCheck("Felles kodeverk", false, kodeverkClient),
-                new SelfTestCheck("Norg2", false, norg2Client),
+               // new SelfTestCheck("Norg2", false, norg2Client),
                 new SelfTestCheck("PDL", true, pdlClient),
                 new SelfTestCheck("skjermede-personer", true, skjermetClient),
                 new SelfTestCheck("Veilarbregistrering", false, veilarbregistreringClient),


### PR DESCRIPTION
* Etter at norg2 har gått over i gcp ser det ut til at de proxier "normale" kall helt fint, men ikke "isAlive"
* Støyende alarmer hos OPS gjør at vi bør gjøre en endring raskt, men siden vi bruker norg2client fra java-modules gjør det at det er begrenset med "egen definert"-url akkurat for å treffe isAliveendepunktet til norg2 i denne overgangsperioden
* Vi skal snart gå over til gcp så vi kan heller da gå mot gcpurlen til norg2 og igjen legge ved isAlivesjekken i vår healthcheck