### PR TITLE
Enkelte arbeidssøkerperioder har ikke opplysninger, men skal fortsatt returnere periodestart

### DIFF
--- a/src/main/java/no/nav/veilarbperson/service/OppslagArbeidssoekerregisteretService.kt
+++ b/src/main/java/no/nav/veilarbperson/service/OppslagArbeidssoekerregisteretService.kt
@@ -32,7 +32,7 @@ class OppslagArbeidssoekerregisteretService(
         }
 
         if (sisteOpplysningerOmArbeidssoeker == null) {
-            throw ResponseStatusException(HttpStatusCode.valueOf(204),"Fant ingen opplysninger om arbeidssoeker")
+            return OpplysningerOmArbeidssoekerMedProfilering(aktivArbeidssoekerperiode.startet.tidspunkt, null, null)
         }
 
         val sisteProfilering =


### PR DESCRIPTION
## Beskriv endringene
Ref: https://nav-it.slack.com/archives/C061Z54S4H3/p1734688772016519
Det finnes enkelte tilfeller hvor man har en arbeidssøkerperiode uten opplysninger. Disse har ikke blitt ryddet opp i. Derfor returnerer vi arbeiddokerperiodedato selv om man ikke har opplysninger å vise.
## Har du testet endringene i dev-miljøet?
- [x] Ja, jeg/vi har testet i dev