### PR TITLE
Legg til endepunkt for fødselsdato

### DIFF
--- a/src/main/java/no/nav/veilarbperson/client/pdl/GqlVariables.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/GqlVariables.java
@@ -39,4 +39,11 @@ public class GqlVariables {
     public static class HentAdressebeskyttelse {
         private Fnr ident;
     }
+
+    @Data
+    @AllArgsConstructor
+    public static class HentFoedselsdato {
+        private Fnr ident;
+    }
+
 }

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -151,6 +151,7 @@ public class HentPerson {
     @Data
     public static class Foedselsdato {
         private LocalDate foedselsdato;
+        private Integer foedselsaar;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Data
 @Accessors(chain = true)
 public class HentPerson {
-    public Person hentPerson;
+    public static Person hentPerson;
     public List<PersonFraBolk> hentPersonBolk;
     public GeografiskTilknytning hentGeografiskTilknytning;
 
@@ -245,6 +245,16 @@ public class HentPerson {
     @Data
     public static class HentFullmaktNavn {
         public PersonNavn hentPerson;
+    }
+
+    @Data
+    public static class PersonFoedselsdato {
+        public List<Foedselsdato> foedselsdato;
+    }
+
+    @Data
+    public static class HentPersonFoedselsdato {
+        public PersonFoedselsdato hentPerson;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Data
 @Accessors(chain = true)
 public class HentPerson {
-    public static Person hentPerson;
+    public Person hentPerson;
     public List<PersonFraBolk> hentPersonBolk;
     public GeografiskTilknytning hentGeografiskTilknytning;
 

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClient.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClient.java
@@ -20,4 +20,6 @@ public interface PdlClient extends HealthCheck {
     HentPerson.HentSpraakTolk hentTilrettelagtKommunikasjon(PdlRequest pdlRequest);
 
     List<HentPerson.Adressebeskyttelse> hentAdressebeskyttelse(PdlRequest pdlRequest);
+
+    HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest);
 }

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClient.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClient.java
@@ -21,5 +21,5 @@ public interface PdlClient extends HealthCheck {
 
     List<HentPerson.Adressebeskyttelse> hentAdressebeskyttelse(PdlRequest pdlRequest);
 
-    HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest);
+    HentPerson.PersonFoedselsdato hentFoedselsdato(PdlRequest pdlRequest);
 }

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -123,7 +124,9 @@ public class PdlClientImpl implements PdlClient {
 
     @Override
     public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
+        Logger log1 = log;
         var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentPerson(pdlRequest.fnr(), false));
+        log1.info("I clienten for foedsesldato");
         return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.Foedselsdato.class);
     }
 

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -18,7 +18,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.slf4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -97,9 +96,7 @@ public class PdlClientImpl implements PdlClient {
 
     @Override
     public HentPerson.PersonFoedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
-        Logger log1 = log;
         var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentFoedselsdato(pdlRequest.fnr()));
-        log1.info("I clienten for foedsesldato med request ", request);
         return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.HentPersonFoedselsdato.class).hentPerson;
     }
 

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -96,6 +96,15 @@ public class PdlClientImpl implements PdlClient {
     }
 
     @Override
+    public HentPerson.PersonFoedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
+        Logger log1 = log;
+        var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentFoedselsdato(pdlRequest.fnr()));
+        log1.info("I clienten for foedsesldato med request ", request);
+        return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.HentPersonFoedselsdato.class).hentPerson;
+    }
+
+
+    @Override
     public List<HentPerson.PersonFraBolk> hentPersonBolk(List<Fnr> personIdenter, String behandlingsnummer) {
         var request = new GqlRequest<>(hentPersonBolkQuery, new GqlVariables.HentPersonBolk(personIdenter, false));
         return (!personIdenter.isEmpty())
@@ -120,14 +129,6 @@ public class PdlClientImpl implements PdlClient {
     public List<HentPerson.Adressebeskyttelse> hentAdressebeskyttelse(PdlRequest pdlRequest) {
         var request = new GqlRequest<>(hentAdressebeskyttelseQuery, new GqlVariables.HentAdressebeskyttelse(pdlRequest.fnr()));
         return graphqlRequest(request, systemTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.class).hentPerson.getAdressebeskyttelse();
-    }
-
-    @Override
-    public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
-        Logger log1 = log;
-        var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentFoedselsdato(pdlRequest.fnr()));
-        log1.info("I clienten for foedsesldato");
-        return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.Foedselsdato.class);
     }
 
     @SneakyThrows
@@ -180,6 +181,7 @@ public class PdlClientImpl implements PdlClient {
     }
 
     private static <T> T parseGqlJsonResponse(String gqlJsonResponse, Class<T> gqlDataClass) throws JsonProcessingException {
+        secureLog.info("Parsing GraphQL response: {}", gqlJsonResponse);
         ObjectMapper mapper = JsonUtils.getMapper();
         JsonNode gqlResponseNode = mapper.readTree(gqlJsonResponse);
         JsonNode errorsNode = gqlResponseNode.get("errors");

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -53,6 +53,8 @@ public class PdlClientImpl implements PdlClient {
 
     private final String hentTilrettelagtKommunikasjonQuery;
 
+    private final String hentFoedselsdatoQuery;
+
     private final AuthService authService;
 
     private final Supplier<String> userTokenProvider;
@@ -71,6 +73,7 @@ public class PdlClientImpl implements PdlClient {
         this.hentGeografiskTilknytningQuery = FileUtils.getResourceFileAsString("graphql/hentGeografiskTilknytning.gql");
         this.hentTilrettelagtKommunikasjonQuery = FileUtils.getResourceFileAsString("graphql/hentTilrettelagtKommunikasjon.gql");
         this.hentAdressebeskyttelseQuery = FileUtils.getResourceFileAsString("graphql/hentAdressebeskyttelse.gql");
+        this.hentFoedselsdatoQuery = FileUtils.getResourceFileAsString("graphql/hentFoedselsdato.gql");
     }
 
     @Override
@@ -116,6 +119,12 @@ public class PdlClientImpl implements PdlClient {
     public List<HentPerson.Adressebeskyttelse> hentAdressebeskyttelse(PdlRequest pdlRequest) {
         var request = new GqlRequest<>(hentAdressebeskyttelseQuery, new GqlVariables.HentAdressebeskyttelse(pdlRequest.fnr()));
         return graphqlRequest(request, systemTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.class).hentPerson.getAdressebeskyttelse();
+    }
+
+    @Override
+    public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
+        var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentPerson(pdlRequest.fnr(), false));
+        return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.Foedselsdato.class);
     }
 
     @SneakyThrows

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -125,7 +125,7 @@ public class PdlClientImpl implements PdlClient {
     @Override
     public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
         Logger log1 = log;
-        var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentPerson(pdlRequest.fnr(), false));
+        var request = new GqlRequest<>(hentFoedselsdatoQuery, new GqlVariables.HentFoedselsdato(pdlRequest.fnr()));
         log1.info("I clienten for foedsesldato");
         return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.Foedselsdato.class);
     }

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -178,7 +178,6 @@ public class PdlClientImpl implements PdlClient {
     }
 
     private static <T> T parseGqlJsonResponse(String gqlJsonResponse, Class<T> gqlDataClass) throws JsonProcessingException {
-        secureLog.info("Parsing GraphQL response: {}", gqlJsonResponse);
         ObjectMapper mapper = JsonUtils.getMapper();
         JsonNode gqlResponseNode = mapper.readTree(gqlJsonResponse);
         JsonNode errorsNode = gqlResponseNode.get("errors");

--- a/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
@@ -144,6 +144,14 @@ public class PersonV3Controller {
         return sisteArbeidssoekerPeriode;
     }
 
+    @PostMapping("/person/hent-foedselsdato")
+    @Operation(summary = "Henter fødselsdato til en person fra PDL")
+    public Foedselsdato hentFoedselsdato(@RequestBody PersonFraPdlRequest personFraPdlRequest) {
+        authService.stoppHvisEksternBruker();
+        authService.sjekkLesetilgang(personFraPdlRequest.getFnr());
+        return personV2Service.hentFoedselsdato(personFraPdlRequest);
+    }
+
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {
         Fnr fnr;
 

--- a/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
@@ -150,7 +150,7 @@ public class PersonV3Controller {
         authService.stoppHvisEksternBruker();
         authService.sjekkLesetilgang(personFraPdlRequest.getFnr());
         //return personV2Service.hentFoedselsdato(personFraPdlRequest);
-        return new Foedselsdato("2000-01-01", 2000);
+        return new Foedselsdato("1990-01-01", 1990);
     }
 
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {

--- a/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
@@ -149,8 +149,7 @@ public class PersonV3Controller {
     public Foedselsdato hentFoedselsdato(@RequestBody PersonFraPdlRequest personFraPdlRequest) {
         authService.stoppHvisEksternBruker();
         authService.sjekkLesetilgang(personFraPdlRequest.getFnr());
-        //return personV2Service.hentFoedselsdato(personFraPdlRequest);
-        return new Foedselsdato("1990-01-01", 1990);
+        return personV2Service.hentFoedselsdato(personFraPdlRequest);
     }
 
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {

--- a/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
+++ b/src/main/java/no/nav/veilarbperson/controller/v3/PersonV3Controller.java
@@ -149,7 +149,8 @@ public class PersonV3Controller {
     public Foedselsdato hentFoedselsdato(@RequestBody PersonFraPdlRequest personFraPdlRequest) {
         authService.stoppHvisEksternBruker();
         authService.sjekkLesetilgang(personFraPdlRequest.getFnr());
-        return personV2Service.hentFoedselsdato(personFraPdlRequest);
+        //return personV2Service.hentFoedselsdato(personFraPdlRequest);
+        return new Foedselsdato("2000-01-01", 2000);
     }
 
     private Fnr hentIdentForEksternEllerIntern(Fnr queryParamFnr) {

--- a/src/main/java/no/nav/veilarbperson/domain/Foedselsdato.kt
+++ b/src/main/java/no/nav/veilarbperson/domain/Foedselsdato.kt
@@ -1,0 +1,7 @@
+package no.nav.veilarbperson.domain
+
+
+data class Foedselsdato(
+    val foedselsdato: String? = null,
+    val foedselsaar: Int
+)

--- a/src/main/java/no/nav/veilarbperson/domain/Foedselsdato.kt
+++ b/src/main/java/no/nav/veilarbperson/domain/Foedselsdato.kt
@@ -1,7 +1,8 @@
 package no.nav.veilarbperson.domain
 
+import java.time.LocalDate
 
 data class Foedselsdato(
-    val foedselsdato: String? = null,
+    val foedselsdato: LocalDate? = null,
     val foedselsaar: Int
 )

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -366,6 +366,7 @@ public class PersonV2Service {
 
     public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
         HentPerson.Foedselsdato person = pdlClient.hentFoedselsdato(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()));
+        log.info("Har hentet foedselsdato person.getFoedselsdato() = {}", person.getFoedselsdato());
         if (person == null ) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke fødselsdato for person");
         }

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -365,6 +365,7 @@ public class PersonV2Service {
     }
 
     public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
+        log.info("Sender til client for foedselsdato");
         HentPerson.Foedselsdato person = pdlClient.hentFoedselsdato(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()));
         log.info("Har hentet foedselsdato person.getFoedselsdato() = {}", person.getFoedselsdato());
         if (person == null ) {

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -366,15 +366,19 @@ public class PersonV2Service {
 
     public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
         log.info("Sender til client for foedselsdato");
-        HentPerson.Foedselsdato person = pdlClient.hentFoedselsdato(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()));
-        log.info("Har hentet foedselsdato person.getFoedselsdato() = {}", person.getFoedselsdato());
-        if (person == null ) {
+        HentPerson.PersonFoedselsdato person = pdlClient.hentFoedselsdato(
+                new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer())
+        );
+        List<HentPerson.Foedselsdato> foedselsdatoer = person.getFoedselsdato();
+
+        log.info("Har hentet foedselsdato = {}", foedselsdatoer);
+
+        if (foedselsdatoer == null || foedselsdatoer.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke fødselsdato for person");
         }
-        return new Foedselsdato(
-                person.getFoedselsdato().toString(),
-                person.getFoedselsaar()
-        );
+
+        HentPerson.Foedselsdato firstFoedselsdato = foedselsdatoer.get(0);
+        return new Foedselsdato(firstFoedselsdato.getFoedselsdato().toString(), firstFoedselsdato.getFoedselsaar());
 
     }
 

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
-import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -363,6 +362,18 @@ public class PersonV2Service {
             log.warn("Kunne ikke hente malform fra KRR", e);
         }
         return null;
+    }
+
+    public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
+        HentPerson.Foedselsdato person = pdlClient.hentFoedselsdato(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()));
+        if (person == null ) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke fødselsdato for person");
+        }
+        return new Foedselsdato(
+                person.getFoedselsdato().toString(),
+                person.getFoedselsaar()
+        );
+
     }
 
     public PersonNavnV2 hentNavn(PersonFraPdlRequest personFraPdlRequest) {

--- a/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
+++ b/src/main/java/no/nav/veilarbperson/service/PersonV2Service.java
@@ -364,24 +364,6 @@ public class PersonV2Service {
         return null;
     }
 
-    public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
-        log.info("Sender til client for foedselsdato");
-        HentPerson.PersonFoedselsdato person = pdlClient.hentFoedselsdato(
-                new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer())
-        );
-        List<HentPerson.Foedselsdato> foedselsdatoer = person.getFoedselsdato();
-
-        log.info("Har hentet foedselsdato = {}", foedselsdatoer);
-
-        if (foedselsdatoer == null || foedselsdatoer.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke fødselsdato for person");
-        }
-
-        HentPerson.Foedselsdato firstFoedselsdato = foedselsdatoer.get(0);
-        return new Foedselsdato(firstFoedselsdato.getFoedselsdato().toString(), firstFoedselsdato.getFoedselsaar());
-
-    }
-
     public PersonNavnV2 hentNavn(PersonFraPdlRequest personFraPdlRequest) {
         HentPerson.PersonNavn personNavn = pdlClient.hentPersonNavn(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()));
 
@@ -395,5 +377,19 @@ public class PersonV2Service {
     public HentPerson.Adressebeskyttelse hentAdressebeskyttelse(PersonFraPdlRequest personFraPdlRequest) {
         List<HentPerson.Adressebeskyttelse> adressebeskyttelse = Optional.ofNullable(pdlClient.hentAdressebeskyttelse(new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer()))).orElse(List.of());
         return adressebeskyttelse.stream().findFirst().orElse(new HentPerson.Adressebeskyttelse().setGradering("UGRADERT"));
+    }
+
+    public Foedselsdato hentFoedselsdato(PersonFraPdlRequest personFraPdlRequest) {
+        HentPerson.PersonFoedselsdato personFoedselsdato = pdlClient.hentFoedselsdato(
+                new PdlRequest(personFraPdlRequest.getFnr(), personFraPdlRequest.getBehandlingsnummer())
+        );
+
+        if (personFoedselsdato.getFoedselsdato().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke fødselsdato for person");
+        }
+
+        HentPerson.Foedselsdato foedselsdato = personFoedselsdato.getFoedselsdato().getFirst();
+        return new Foedselsdato(foedselsdato.getFoedselsdato(), foedselsdato.getFoedselsaar());
+
     }
 }

--- a/src/main/resources/graphql/hentFoedselsdato.gql
+++ b/src/main/resources/graphql/hentFoedselsdato.gql
@@ -1,8 +1,8 @@
 query($ident: ID!, $historikk: Boolean!) {
     hentPerson(ident: $ident) {
-            foedselsdato {
-                foedselsdato
-                foedselsaar
-            }
+        foedselsdato {
+            foedselsdato
+            foedselsaar
+        }
     }
 }

--- a/src/main/resources/graphql/hentFoedselsdato.gql
+++ b/src/main/resources/graphql/hentFoedselsdato.gql
@@ -1,4 +1,4 @@
-query($ident: ID!, $historikk: Boolean!) {
+query($ident: ID!) {
     hentPerson(ident: $ident) {
         foedselsdato {
             foedselsdato

--- a/src/main/resources/graphql/hentFoedselsdato.gql
+++ b/src/main/resources/graphql/hentFoedselsdato.gql
@@ -1,0 +1,8 @@
+query($ident: ID!, $historikk: Boolean!) {
+    hentPerson(ident: $ident) {
+            foedselsdato {
+                foedselsdato
+                foedselsaar
+            }
+    }
+}

--- a/src/main/resources/graphql/hentPerson.gql
+++ b/src/main/resources/graphql/hentPerson.gql
@@ -11,6 +11,7 @@ query($ident: ID!, $historikk: Boolean!) {
         }
         foedselsdato {
             foedselsdato
+            foedselsaar
         }
         kjoenn {
             kjoenn

--- a/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
@@ -220,7 +220,7 @@ public class ClientTestConfig {
             }
 
             @Override
-            public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {return null; }
+            public HentPerson.PersonFoedselsdato hentFoedselsdato(PdlRequest pdlRequest) {return null; }
         };
     }
 

--- a/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
+++ b/src/test/java/no/nav/veilarbperson/config/ClientTestConfig.java
@@ -218,6 +218,9 @@ public class ClientTestConfig {
             public HealthCheckResult checkHealth() {
                 return HealthCheckResult.healthy();
             }
+
+            @Override
+            public HentPerson.Foedselsdato hentFoedselsdato(PdlRequest pdlRequest) {return null; }
         };
     }
 

--- a/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
@@ -22,10 +22,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDate;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static no.nav.veilarbperson.utils.TestData.TEST_FNR;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -506,6 +509,7 @@ public class PersonV3ControllerTest {
                 )
                 .andExpect(status().is(204));
     }
+
     @Test
     void test_av_hent_navn() throws Exception {
         PrivatBruker ny = navContext.getPrivatBrukere().ny();
@@ -532,7 +536,8 @@ public class PersonV3ControllerTest {
     void test_av_hent_foedselsdato() throws Exception {
         PrivatBruker ny = navContext.getPrivatBrukere().ny();
         NavAnsatt navAnsatt = navContext.getNavAnsatt().nyFor(ny);
-        when(personV2Service.hentFoedselsdato(new PersonFraPdlRequest(TEST_FNR, "B555"))).thenReturn(new Foedselsdato("1990-01-01", 1990));
+        when(personV2Service.hentFoedselsdato(new PersonFraPdlRequest(TEST_FNR, "B555")))
+                .thenReturn(new Foedselsdato(LocalDate.of(1990, 1, 1), 1990));
 
         String expectedJson = "{\"foedselsdato\":\"1990-01-01\",\"foedselsaar\":1990}";
 

--- a/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
+++ b/src/test/java/no/nav/veilarbperson/controller/PersonV3ControllerTest.java
@@ -8,6 +8,7 @@ import no.nav.poao_tilgang.poao_tilgang_test_core.NavContext;
 import no.nav.poao_tilgang.poao_tilgang_test_core.PrivatBruker;
 import no.nav.veilarbperson.config.ApplicationTestConfig;
 import no.nav.veilarbperson.controller.v3.PersonV3Controller;
+import no.nav.veilarbperson.domain.Foedselsdato;
 import no.nav.veilarbperson.domain.PersonFraPdlRequest;
 import no.nav.veilarbperson.domain.PersonNavnV2;
 import no.nav.veilarbperson.domain.PersonV2Data;
@@ -526,4 +527,27 @@ public class PersonV3ControllerTest {
                 .andExpect(content().json(expectedJson))
                 .andExpect(status().is(200));
     }
+
+    @Test
+    void test_av_hent_foedselsdato() throws Exception {
+        PrivatBruker ny = navContext.getPrivatBrukere().ny();
+        NavAnsatt navAnsatt = navContext.getNavAnsatt().nyFor(ny);
+        when(personV2Service.hentFoedselsdato(new PersonFraPdlRequest(TEST_FNR, "B555"))).thenReturn(new Foedselsdato("1990-01-01", 1990));
+
+        String expectedJson = "{\"foedselsdato\":\"1990-01-01\",\"foedselsaar\":1990}";
+
+        mockMvc
+                .perform(
+                        post("/api/v3/person/hent-foedselsdato")
+                                .contentType(APPLICATION_JSON)
+                                .content(JsonUtils.toJson(new PersonFraPdlRequest(TEST_FNR, "B555")))
+                                .header(ACCEPT, APPLICATION_JSON_VALUE)
+                                .header(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                                .header("test_ident", navAnsatt.getNavIdent())
+                                .header("test_ident_type", "INTERN")
+                )
+                .andExpect(content().string(expectedJson))
+                .andExpect(status().is(200));
+    }
+
 }

--- a/src/test/java/no/nav/veilarbperson/service/PersonV2ServiceTest.java
+++ b/src/test/java/no/nav/veilarbperson/service/PersonV2ServiceTest.java
@@ -92,6 +92,11 @@ public class PersonV2ServiceTest extends PdlClientTestConfig {
         return pdlClient.hentPersonNavn(pdlRequest);
     }
 
+    public HentPerson.PersonFoedselsdato hentFoedselsdato(PdlRequest pdlRequest) {
+        configurePdlResponse("pdl-hentFoedselsdato-response.json", pdlRequest.fnr().get());
+        return pdlClient.hentFoedselsdato(pdlRequest);
+    }
+
     public HentPerson.Verge hentVerge(Fnr fnr) {
         configurePdlResponse("pdl-hentVerge-response.json", fnr.get());
         return pdlClient.hentVerge(new PdlRequest(fnr, null));
@@ -185,6 +190,14 @@ public class PersonV2ServiceTest extends PdlClientTestConfig {
         assertEquals("GLITRENDE", navn.getMellomnavn());
         assertEquals("STAFFELI", navn.getEtternavn());
         assertEquals("NATURLIG STAFFELI", navn.getForkortetNavn());
+    }
+
+    @Test
+    public void hentFoedselsdatoTest() {
+        HentPerson.Foedselsdato dato = person.getFoedselsdato().getFirst();
+
+        assertEquals(LocalDate.of(1981, 12, 13), dato.getFoedselsdato());
+        assertEquals(1981, dato.getFoedselsaar());
     }
 
     @Test
@@ -473,6 +486,14 @@ public class PersonV2ServiceTest extends PdlClientTestConfig {
         assertEquals("OLA", navn.getFornavn());
         assertEquals("NORDMANN", navn.getEtternavn());
         assertEquals("NORDMANN OLA", navn.getForkortetNavn());
+    }
+
+    @Test
+    public void foedselsdatoMapperTest() {
+        HentPerson.PersonFoedselsdato foedselsdatoPerson = hentFoedselsdato(new PdlRequest(FNR, null));
+        HentPerson.Foedselsdato foedselsdato = foedselsdatoPerson.getFoedselsdato().getFirst();
+        assertEquals(LocalDate.of(1982, 12, 13), foedselsdato.getFoedselsdato());
+        assertEquals(1982, foedselsdato.getFoedselsaar());
     }
 
     @Test

--- a/src/test/resources/pdl-hentFoedselsdato-response.json
+++ b/src/test/resources/pdl-hentFoedselsdato-response.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "hentPerson": {
+      "foedselsdato": [
+        {
+          "foedselsdato": "1982-12-13",
+          "foedselsaar": 1982
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/pdl-hentPerson-response.json
+++ b/src/test/resources/pdl-hentPerson-response.json
@@ -14,7 +14,8 @@
       ],
       "foedselsdato": [
         {
-          "foedselsdato": "1981-12-13"
+          "foedselsdato": "1981-12-13",
+          "foedselsaar": 1981
         }
       ],
       "kjoenn": [],


### PR DESCRIPTION
## Beskriv endringene
Lagt til et endepunkt for å hente ut fødselsdato og år fra pdl. Dette trengs for å regne ut alder, og er bedre å hente fødselsdato enn å bruke personnummer siden dette alltid vil stemme overens med f.dato fremover. I følge pdl så skal de aller fleste ha _fødselsdato_, men det er ikke 100% dekning. Alle skal derimot ha _fødselsår_, så tar derfor med dette i tillegg. 

## Har du testet endringene i dev-miljøet?
- [x] Ja, jeg/vi har testet i dev -> hent-person fungerer som normalt, og endpunktet hent-foedselsdato henter ut dato og fødselsår som forventet. 
