### PR TITLE
Oppdater vergedata med identifiserende informasjon

### DIFF
--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -231,6 +231,7 @@ public class HentPerson {
     public static class Folkeregistermetadata {
         public LocalDateTime ajourholdstidspunkt;
         public LocalDateTime gyldighetstidspunkt;
+        public LocalDateTime opphoerstidspunkt;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -208,10 +208,17 @@ public class HentPerson {
 
     @Data
     public static class VergeEllerFullmektig {
-        private VergeNavn navn;
-        private IdentifiserendeInformasjon identifiserendeInformasjon;
+        //private VergeNavn navn;  deprecated
+        private IdentifiserendeInformasjon identifiserendeInformasjon; // kun for de som ikke har motpartsPersonident
         private String motpartsPersonident;
-        private VergemaalEllerFullmaktOmfangType omfang;
+        private VergemaalEllerFullmaktOmfangType omfang; // kun på historiske vergemål før 11.2023
+        private List<Tjenesteomraade> tjenesteomraade;
+    }
+
+    @Data
+    public static class Tjenesteomraade {
+        private String tjenesteoppgave;
+        private String tjenestevirksomhet;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -209,8 +209,14 @@ public class HentPerson {
     @Data
     public static class VergeEllerFullmektig {
         private VergeNavn navn;
+        private IdentifiserendeInformasjon identifiserendeInformasjon;
         private String motpartsPersonident;
         private VergemaalEllerFullmaktOmfangType omfang;
+    }
+
+    @Data
+    public static class IdentifiserendeInformasjon {
+        private VergeNavn navn;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/HentPerson.java
@@ -217,7 +217,7 @@ public class HentPerson {
 
     @Data
     public static class Tjenesteomraade {
-        private String tjenesteoppgave;
+        private VergemaalEllerFullmaktTjenesteoppgaveType tjenesteoppgave;
         private String tjenestevirksomhet;
     }
 

--- a/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/PdlClientImpl.java
@@ -100,7 +100,6 @@ public class PdlClientImpl implements PdlClient {
         return graphqlRequest(request, authService.erSystemBruker() ? systemTokenProvider.get() : userTokenProvider.get(), pdlRequest.behandlingsnummer(), HentPerson.HentPersonFoedselsdato.class).hentPerson;
     }
 
-
     @Override
     public List<HentPerson.PersonFraBolk> hentPersonBolk(List<Fnr> personIdenter, String behandlingsnummer) {
         var request = new GqlRequest<>(hentPersonBolkQuery, new GqlVariables.HentPersonBolk(personIdenter, false));

--- a/src/main/java/no/nav/veilarbperson/client/pdl/domain/VergemaalEllerFullmaktTjenesteoppgaveType.java
+++ b/src/main/java/no/nav/veilarbperson/client/pdl/domain/VergemaalEllerFullmaktTjenesteoppgaveType.java
@@ -1,0 +1,17 @@
+package no.nav.veilarbperson.client.pdl.domain;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+
+public enum VergemaalEllerFullmaktTjenesteoppgaveType {
+    @JsonAlias("familie")
+    FAMILIE,
+    @JsonAlias("arbeid")
+    ARBEID,
+    @JsonAlias("hjelpemidler")
+    HJELPEMIDLER,
+    @JsonAlias("pensjon")
+    PENSJON,
+    @JsonAlias("sosialeTjenester")
+    SOSIALE_TJENESTER,
+}
+

--- a/src/main/java/no/nav/veilarbperson/domain/VergeData.java
+++ b/src/main/java/no/nav/veilarbperson/domain/VergeData.java
@@ -32,8 +32,14 @@ public class VergeData {
     @Data
     public static class VergeEllerFullmektig {
         private VergeNavn navn;
+        private IdentifiserendeInformasjon identifiserendeInformasjon;
         private String motpartsPersonident;
         private VergemaalEllerFullmaktOmfangType omfang;
+    }
+
+    @Data
+    public static class IdentifiserendeInformasjon {
+        private VergeNavn navn;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/domain/VergeData.java
+++ b/src/main/java/no/nav/veilarbperson/domain/VergeData.java
@@ -3,6 +3,7 @@ package no.nav.veilarbperson.domain;
 import lombok.Data;
 import lombok.experimental.Accessors;
 import no.nav.veilarbperson.client.pdl.domain.VergemaalEllerFullmaktOmfangType;
+import no.nav.veilarbperson.client.pdl.domain.VergemaalEllerFullmaktTjenesteoppgaveType;
 import no.nav.veilarbperson.client.pdl.domain.Vergetype;
 
 import java.time.LocalDateTime;
@@ -31,7 +32,7 @@ public class VergeData {
 
     @Data
     public static class Tjenesteomraade {
-        private String tjenesteoppgave;
+        private VergemaalEllerFullmaktTjenesteoppgaveType tjenesteoppgave;
         private String tjenestevirksomhet;
     }
 

--- a/src/main/java/no/nav/veilarbperson/domain/VergeData.java
+++ b/src/main/java/no/nav/veilarbperson/domain/VergeData.java
@@ -54,5 +54,6 @@ public class VergeData {
     public static class Folkeregistermetadata {
         public LocalDateTime ajourholdstidspunkt;
         public LocalDateTime gyldighetstidspunkt;
+        public LocalDateTime opphoerstidspunkt;
     }
 }

--- a/src/main/java/no/nav/veilarbperson/domain/VergeData.java
+++ b/src/main/java/no/nav/veilarbperson/domain/VergeData.java
@@ -15,14 +15,6 @@ public class VergeData {
     public List<VergemaalEllerFremtidsfullmakt> vergemaalEllerFremtidsfullmakt;
 
     @Data
-    public static class Navn {
-        private String fornavn;
-        private String mellomnavn;
-        private String etternavn;
-        private String forkortetNavn;
-    }
-
-    @Data
     public static class VergeNavn {
         private String fornavn;
         private String mellomnavn;
@@ -32,14 +24,15 @@ public class VergeData {
     @Data
     public static class VergeEllerFullmektig {
         private VergeNavn navn;
-        private IdentifiserendeInformasjon identifiserendeInformasjon;
         private String motpartsPersonident;
         private VergemaalEllerFullmaktOmfangType omfang;
+        private List<Tjenesteomraade> tjenesteomraade;
     }
 
     @Data
-    public static class IdentifiserendeInformasjon {
-        private VergeNavn navn;
+    public static class Tjenesteomraade {
+        private String tjenesteoppgave;
+        private String tjenestevirksomhet;
     }
 
     @Data

--- a/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
+++ b/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
@@ -88,6 +88,7 @@ public class VergeOgFullmaktDataMapper {
     public static VergeData.Folkeregistermetadata folkeregisterMetadataMapper(HentPerson.Folkeregistermetadata folkeregistermetadata) {
         return new VergeData.Folkeregistermetadata()
                 .setAjourholdstidspunkt(folkeregistermetadata.getAjourholdstidspunkt())
-                .setGyldighetstidspunkt(folkeregistermetadata.getGyldighetstidspunkt());
+                .setGyldighetstidspunkt(folkeregistermetadata.getGyldighetstidspunkt())
+                .setOpphoerstidspunkt(folkeregistermetadata.getOpphoerstidspunkt());
     }
 }

--- a/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
+++ b/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
@@ -3,36 +3,31 @@ package no.nav.veilarbperson.utils;
 import no.nav.veilarbperson.client.pdl.HentPerson;
 import no.nav.veilarbperson.client.representasjon.ReprFullmaktData;
 import no.nav.veilarbperson.domain.FullmaktDTO;
+import no.nav.veilarbperson.domain.PersonNavnV2;
 import no.nav.veilarbperson.domain.VergeData;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class VergeOgFullmaktDataMapper {
-
-    public static VergeData toVerge(HentPerson.Verge vergeOgFullmaktFraPdl) {
-        return new VergeData()
-                .setVergemaalEllerFremtidsfullmakt(vergemaalEllerFremtidsfullmaktMapper(vergeOgFullmaktFraPdl.getVergemaalEllerFremtidsfullmakt()));
-    }
-
     public static FullmaktDTO toFullmaktDTO(List<ReprFullmaktData.Fullmakt> fullmaktListe) {
         return new FullmaktDTO()
                 .setFullmakt(representasjonFullmaktMapper(fullmaktListe)
-        );
+                );
     }
 
     public static List<FullmaktDTO.Fullmakt> representasjonFullmaktMapper(List<ReprFullmaktData.Fullmakt> fullmaktListe) {
         return fullmaktListe.stream()
-            .map(fullmakt ->
-                new FullmaktDTO.Fullmakt()
-                        .setFullmaktsgiver(fullmakt.getFullmaktsgiver())
-                        .setFullmaktsgiverNavn(fullmakt.getFullmaktsgiverNavn())
-                        .setFullmektig(fullmakt.getFullmektig())
-                        .setFullmektigsNavn(fullmakt.getFullmektigsNavn())
-                        .setOmraade(omraadeMapper(fullmakt.getOmraade()))
-                        .setGyldigFraOgMed(fullmakt.getGyldigFraOgMed())
-                        .setGyldigTilOgMed(fullmakt.getGyldigTilOgMed()))
-            .collect(Collectors.toList());
+                .map(fullmakt ->
+                        new FullmaktDTO.Fullmakt()
+                                .setFullmaktsgiver(fullmakt.getFullmaktsgiver())
+                                .setFullmaktsgiverNavn(fullmakt.getFullmaktsgiverNavn())
+                                .setFullmektig(fullmakt.getFullmektig())
+                                .setFullmektigsNavn(fullmakt.getFullmektigsNavn())
+                                .setOmraade(omraadeMapper(fullmakt.getOmraade()))
+                                .setGyldigFraOgMed(fullmakt.getGyldigFraOgMed())
+                                .setGyldigTilOgMed(fullmakt.getGyldigTilOgMed()))
+                .collect(Collectors.toList());
     }
 
     public static List<FullmaktDTO.OmraadeMedHandling> omraadeMapper(List<ReprFullmaktData.OmraadeMedHandling> omraade) {
@@ -40,8 +35,8 @@ public class VergeOgFullmaktDataMapper {
             List<ReprFullmaktData.OmraadeHandlingType> reprHandlingTyper = omraadeMedHandling.getHandling();
             List<FullmaktDTO.OmraadeHandlingType> fullmaktHandlingTyper =
                     reprHandlingTyper.stream().map(
-                        omraadeHandlingType -> FullmaktDTO.OmraadeHandlingType.valueOf(omraadeHandlingType.name()))
-                    .toList();
+                                    omraadeHandlingType -> FullmaktDTO.OmraadeHandlingType.valueOf(omraadeHandlingType.name()))
+                            .toList();
             FullmaktDTO.OmraadeMedHandling omraadeMedHandlingMapper = new FullmaktDTO.OmraadeMedHandling();
             omraadeMedHandlingMapper
                     .setTema(omraadeMedHandling.getTema())
@@ -50,39 +45,44 @@ public class VergeOgFullmaktDataMapper {
         }).toList();
     }
 
-    public static List<VergeData.VergemaalEllerFremtidsfullmakt> vergemaalEllerFremtidsfullmaktMapper(List<HentPerson.VergemaalEllerFremtidsfullmakt> vergemaalEllerFremtidsfullmaktListe) {
-            return vergemaalEllerFremtidsfullmaktListe.stream()
-                  .map(vergemaalEllerFremtidsfullmakt ->
-                       new VergeData.VergemaalEllerFremtidsfullmakt()
-                             .setType(vergemaalEllerFremtidsfullmakt.getType())
-                             .setEmbete(vergemaalEllerFremtidsfullmakt.getEmbete())
-                             .setVergeEllerFullmektig(vergeEllerFullmektigMapper(vergemaalEllerFremtidsfullmakt.getVergeEllerFullmektig()))
-                             .setFolkeregistermetadata(folkeregisterMetadataMapper(vergemaalEllerFremtidsfullmakt.getFolkeregistermetadata())))
-                  .collect(Collectors.toList());
+    public static VergeData.VergemaalEllerFremtidsfullmakt toVergemaalEllerFremtidsfullmakt(HentPerson.VergemaalEllerFremtidsfullmakt vergemaalEllerFremtidsfullmakt, PersonNavnV2 navn) {
+        return new VergeData.VergemaalEllerFremtidsfullmakt()
+                .setType(vergemaalEllerFremtidsfullmakt.getType())
+                .setEmbete(vergemaalEllerFremtidsfullmakt.getEmbete())
+                .setVergeEllerFullmektig(vergeEllerFullmektigMapper(vergemaalEllerFremtidsfullmakt.getVergeEllerFullmektig(), navn))
+                .setFolkeregistermetadata(folkeregisterMetadataMapper(vergemaalEllerFremtidsfullmakt.getFolkeregistermetadata()));
     }
 
-    public static VergeData.VergeEllerFullmektig vergeEllerFullmektigMapper(HentPerson.VergeEllerFullmektig vergeEllerFullmektig) {
+    public static VergeData.VergeEllerFullmektig vergeEllerFullmektigMapper(HentPerson.VergeEllerFullmektig vergeEllerFullmektig, PersonNavnV2 navn) {
+        VergeData.VergeNavn vergeNavn;
+
+        if (navn != null) {
+            vergeNavn = personnavnTilVergenavnMapper(navn);
+        } else {
+            vergeNavn = vergeNavnMapper(vergeEllerFullmektig.getIdentifiserendeInformasjon().getNavn());
+        }
+
         return new VergeData.VergeEllerFullmektig()
-                .setNavn(vergeNavnMapper(vergeEllerFullmektig.getNavn()))
-                .setIdentifiserendeInformasjon(identifiserendeInformasjonMapper(vergeEllerFullmektig.getIdentifiserendeInformasjon()))
+                .setNavn(vergeNavn)
                 .setMotpartsPersonident(vergeEllerFullmektig.getMotpartsPersonident())
-                .setOmfang(vergeEllerFullmektig.getOmfang());
+                .setOmfang(vergeEllerFullmektig.getOmfang())
+                .setTjenesteomraade(vergeEllerFullmektig.getTjenesteomraade().stream()
+                        .map(tjenesteomraade -> new VergeData.Tjenesteomraade()
+                                .setTjenesteoppgave(tjenesteomraade.getTjenesteoppgave())
+                                .setTjenestevirksomhet(tjenesteomraade.getTjenestevirksomhet()))
+                        .collect(Collectors.toList()));
     }
 
-    public static VergeData.IdentifiserendeInformasjon identifiserendeInformasjonMapper(HentPerson.IdentifiserendeInformasjon identifiserendeInformasjon) {
-        return new VergeData.IdentifiserendeInformasjon()
-                .setNavn(vergeNavnMapper(identifiserendeInformasjon.getNavn()));
-    }
-
-    public static VergeData.VergeNavn vergeNavnMapper(HentPerson.VergeNavn vergeNavn) {
-        return (vergeNavn!=null)
-                ? new VergeData.VergeNavn().setFornavn(vergeNavn.getFornavn()).setMellomnavn(vergeNavn.getMellomnavn()).setEtternavn(vergeNavn.getEtternavn())
+    public static VergeData.VergeNavn personnavnTilVergenavnMapper(PersonNavnV2 navn) {
+        return (navn != null)
+                ? new VergeData.VergeNavn().setFornavn(navn.getFornavn()).setMellomnavn(navn.getMellomnavn()).setEtternavn(navn.getEtternavn())
                 : null;
     }
 
-    public static VergeData.Navn personNavnMapper(List<HentPerson.Navn> motpartspersonnavn) {
-        HentPerson.Navn navn = PersonV2DataMapper.getFirstElement(motpartspersonnavn);
-        return new VergeData.Navn().setFornavn(navn.getFornavn()).setMellomnavn(navn.getMellomnavn()).setEtternavn(navn.getEtternavn()).setForkortetNavn(navn.getForkortetNavn());
+    public static VergeData.VergeNavn vergeNavnMapper(HentPerson.VergeNavn vergeNavn) {
+        return (vergeNavn != null)
+                ? new VergeData.VergeNavn().setFornavn(vergeNavn.getFornavn()).setMellomnavn(vergeNavn.getMellomnavn()).setEtternavn(vergeNavn.getEtternavn())
+                : null;
     }
 
     public static VergeData.Folkeregistermetadata folkeregisterMetadataMapper(HentPerson.Folkeregistermetadata folkeregistermetadata) {

--- a/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
+++ b/src/main/java/no/nav/veilarbperson/utils/VergeOgFullmaktDataMapper.java
@@ -64,8 +64,14 @@ public class VergeOgFullmaktDataMapper {
     public static VergeData.VergeEllerFullmektig vergeEllerFullmektigMapper(HentPerson.VergeEllerFullmektig vergeEllerFullmektig) {
         return new VergeData.VergeEllerFullmektig()
                 .setNavn(vergeNavnMapper(vergeEllerFullmektig.getNavn()))
+                .setIdentifiserendeInformasjon(identifiserendeInformasjonMapper(vergeEllerFullmektig.getIdentifiserendeInformasjon()))
                 .setMotpartsPersonident(vergeEllerFullmektig.getMotpartsPersonident())
                 .setOmfang(vergeEllerFullmektig.getOmfang());
+    }
+
+    public static VergeData.IdentifiserendeInformasjon identifiserendeInformasjonMapper(HentPerson.IdentifiserendeInformasjon identifiserendeInformasjon) {
+        return new VergeData.IdentifiserendeInformasjon()
+                .setNavn(vergeNavnMapper(identifiserendeInformasjon.getNavn()));
     }
 
     public static VergeData.VergeNavn vergeNavnMapper(HentPerson.VergeNavn vergeNavn) {

--- a/src/main/resources/graphql/hentVerge.gql
+++ b/src/main/resources/graphql/hentVerge.gql
@@ -18,6 +18,10 @@ query($ident: ID!, $historikk: Boolean!) {
                 }
                 motpartsPersonident
                 omfang
+                tjenesteomraade {
+                    tjenesteoppgave
+                    tjenestevirksomhet
+                  }
             }
             folkeregistermetadata {
                 ajourholdstidspunkt

--- a/src/main/resources/graphql/hentVerge.gql
+++ b/src/main/resources/graphql/hentVerge.gql
@@ -9,6 +9,13 @@ query($ident: ID!, $historikk: Boolean!) {
                     mellomnavn
                     etternavn
                 }
+                identifiserendeInformasjon {
+                    navn {
+                        fornavn
+                        mellomnavn
+                        etternavn
+                    }
+                }
                 motpartsPersonident
                 omfang
             }

--- a/src/main/resources/graphql/hentVerge.gql
+++ b/src/main/resources/graphql/hentVerge.gql
@@ -22,6 +22,7 @@ query($ident: ID!, $historikk: Boolean!) {
             folkeregistermetadata {
                 ajourholdstidspunkt
                 gyldighetstidspunkt
+                opphoerstidspunkt
             }
         }
     }

--- a/src/test/java/no/nav/veilarbperson/client/PdlClientImplTest.java
+++ b/src/test/java/no/nav/veilarbperson/client/PdlClientImplTest.java
@@ -183,7 +183,6 @@ public class PdlClientImplTest {
         assertEquals("VergemallEmbete", vergemaal.getEmbete());
         assertEquals(VergemaalEllerFullmaktOmfangType.OEKONOMISKE_INTERESSER, vergeEllerFullmektig.getOmfang());
         assertEquals("VergeMotpartsPersonident1", vergeEllerFullmektig.getMotpartsPersonident());
-        assertEquals("vergeEtternavn1", vergeEllerFullmektig.getNavn().getEtternavn());
     }
 
     @Test

--- a/src/test/java/no/nav/veilarbperson/utils/mappers/VergeOgFullmaktDataMapperTest.java
+++ b/src/test/java/no/nav/veilarbperson/utils/mappers/VergeOgFullmaktDataMapperTest.java
@@ -4,6 +4,7 @@ import no.nav.common.types.identer.Fnr;
 import no.nav.veilarbperson.client.pdl.HentPerson;
 import no.nav.veilarbperson.client.pdl.domain.PdlRequest;
 import no.nav.veilarbperson.client.pdl.domain.VergemaalEllerFullmaktOmfangType;
+import no.nav.veilarbperson.client.pdl.domain.VergemaalEllerFullmaktTjenesteoppgaveType;
 import no.nav.veilarbperson.client.pdl.domain.Vergetype;
 import no.nav.veilarbperson.config.PdlClientTestConfig;
 import no.nav.veilarbperson.domain.PersonNavnV2;
@@ -69,7 +70,7 @@ public class VergeOgFullmaktDataMapperTest extends PdlClientTestConfig {
         VergeData.VergeEllerFullmektig vergeEllerFullmektigDataLast = vergeOgFullmaktDataLast.getVergeEllerFullmektig();
         assertEquals("Testfornavnavn1", vergeEllerFullmektigDataLast.getNavn().getFornavn());
         assertEquals(5, vergeEllerFullmektigDataLast.getTjenesteomraade().size());
-        assertEquals("arbeid", vergeEllerFullmektigDataLast.getTjenesteomraade().getFirst().getTjenesteoppgave());
+        assertEquals(VergemaalEllerFullmaktTjenesteoppgaveType.ARBEID, vergeEllerFullmektigDataLast.getTjenesteomraade().getFirst().getTjenesteoppgave());
     }
 
 }

--- a/src/test/java/no/nav/veilarbperson/utils/mappers/VergeOgFullmaktDataMapperTest.java
+++ b/src/test/java/no/nav/veilarbperson/utils/mappers/VergeOgFullmaktDataMapperTest.java
@@ -6,6 +6,7 @@ import no.nav.veilarbperson.client.pdl.domain.PdlRequest;
 import no.nav.veilarbperson.client.pdl.domain.VergemaalEllerFullmaktOmfangType;
 import no.nav.veilarbperson.client.pdl.domain.Vergetype;
 import no.nav.veilarbperson.config.PdlClientTestConfig;
+import no.nav.veilarbperson.domain.PersonNavnV2;
 import no.nav.veilarbperson.domain.VergeData;
 import no.nav.veilarbperson.utils.TestUtils;
 import no.nav.veilarbperson.utils.VergeOgFullmaktDataMapper;
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static java.util.Optional.ofNullable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VergeOgFullmaktDataMapperTest extends PdlClientTestConfig {
 
@@ -45,24 +47,29 @@ public class VergeOgFullmaktDataMapperTest extends PdlClientTestConfig {
     @Test
     public void toVergeOgFullmaktDataTest() {
         HentPerson.Verge vergeOgFullmaktFraPdl = hentVerge(FNR);
-        VergeData vergeOgFullmaktData = VergeOgFullmaktDataMapper.toVerge(vergeOgFullmaktFraPdl);
+        VergeData.VergemaalEllerFremtidsfullmakt vergeOgFullmaktDataFirst = VergeOgFullmaktDataMapper.toVergemaalEllerFremtidsfullmakt(vergeOgFullmaktFraPdl.getVergemaalEllerFremtidsfullmakt().getFirst(), null);
 
-        List<VergeData.VergemaalEllerFremtidsfullmakt> vergemaalEllerFremtidsfullmaktData = vergeOgFullmaktData.getVergemaalEllerFremtidsfullmakt();
+        assertEquals(Vergetype.MIDLERTIDIG_FOR_VOKSEN, vergeOgFullmaktDataFirst.getType());
+        assertEquals("VergemallEmbete", vergeOgFullmaktDataFirst.getEmbete());
+        VergeData.VergeEllerFullmektig vergeEllerFullmektigDataFirst = vergeOgFullmaktDataFirst.getVergeEllerFullmektig();
 
-        assertEquals(2, vergemaalEllerFremtidsfullmaktData.size());
-        assertEquals(Vergetype.MIDLERTIDIG_FOR_VOKSEN, vergemaalEllerFremtidsfullmaktData.get(0).getType());
-        assertEquals("VergemallEmbete", vergemaalEllerFremtidsfullmaktData.get(0).getEmbete());
+        assertEquals("vergeFornavn1", vergeEllerFullmektigDataFirst.getNavn().getFornavn());
+        assertEquals("VergeMotpartsPersonident1", vergeEllerFullmektigDataFirst.getMotpartsPersonident());
+        assertEquals(VergemaalEllerFullmaktOmfangType.OEKONOMISKE_INTERESSER, vergeEllerFullmektigDataFirst.getOmfang());
+        assertTrue(vergeEllerFullmektigDataFirst.getTjenesteomraade().isEmpty());
 
-        VergeData.VergeEllerFullmektig vergeEllerFullmektigData = vergemaalEllerFremtidsfullmaktData.get(0).getVergeEllerFullmektig();
-
-        assertEquals("vergeFornavn1", vergeEllerFullmektigData.getNavn().getFornavn());
-        assertEquals("VergeMotpartsPersonident1", vergeEllerFullmektigData.getMotpartsPersonident());
-        assertEquals(VergemaalEllerFullmaktOmfangType.OEKONOMISKE_INTERESSER, vergeEllerFullmektigData.getOmfang());
-
-        VergeData.Folkeregistermetadata folkeregistermetadata = vergemaalEllerFremtidsfullmaktData.get(0).getFolkeregistermetadata();
+        VergeData.Folkeregistermetadata folkeregistermetadata = vergeOgFullmaktDataFirst.getFolkeregistermetadata();
         LocalDateTime localDateTime = LocalDateTime.of(LocalDate.of(2021, 03, 02), LocalTime.of(13, 00, 42));
         assertEquals(localDateTime, folkeregistermetadata.getAjourholdstidspunkt());
         assertEquals(localDateTime, folkeregistermetadata.getGyldighetstidspunkt());
+
+        PersonNavnV2 personnavn = new PersonNavnV2().setFornavn("Testfornavnavn1").setEtternavn("Testetternavn1");
+        VergeData.VergemaalEllerFremtidsfullmakt vergeOgFullmaktDataLast = VergeOgFullmaktDataMapper.toVergemaalEllerFremtidsfullmakt(vergeOgFullmaktFraPdl.getVergemaalEllerFremtidsfullmakt().getLast(), personnavn);
+
+        VergeData.VergeEllerFullmektig vergeEllerFullmektigDataLast = vergeOgFullmaktDataLast.getVergeEllerFullmektig();
+        assertEquals("Testfornavnavn1", vergeEllerFullmektigDataLast.getNavn().getFornavn());
+        assertEquals(5, vergeEllerFullmektigDataLast.getTjenesteomraade().size());
+        assertEquals("arbeid", vergeEllerFullmektigDataLast.getTjenesteomraade().getFirst().getTjenesteoppgave());
     }
 
 }

--- a/src/test/resources/pdl-hentVerge-response.json
+++ b/src/test/resources/pdl-hentVerge-response.json
@@ -6,11 +6,6 @@
           "type": "midlertidigForVoksen",
           "embete": "VergemallEmbete",
           "vergeEllerFullmektig" : {
-            "navn": {
-              "fornavn": "vergeFornavn1",
-              "mellomnavn": "vergeMellomnavn1",
-              "etternavn": "vergeEtternavn1"
-            },
             "identifiserendeInformasjon": {
               "navn": {
                 "fornavn": "vergeFornavn1",
@@ -19,7 +14,8 @@
               }
             },
             "motpartsPersonident": "VergeMotpartsPersonident1",
-            "omfang": "oekonomiskeInteresser"
+            "omfang": "oekonomiskeInteresser",
+            "tjenesteomraade": []
           },
           "folkeregistermetadata": {
             "ajourholdstidspunkt":  "2021-03-02T13:00:42",
@@ -31,11 +27,6 @@
           "type": "stadfestetFremtidsfullmakt",
           "embete": "VergemallEmbete",
           "vergeEllerFullmektig" : {
-            "navn": {
-              "fornavn": "vergeFornavn2",
-              "mellomnavn": "vergeMellomnavn2",
-              "etternavn": "vergeEtternavn2"
-            },
             "identifiserendeInformasjon": {
               "navn": {
                 "fornavn": "vergeFornavn2",
@@ -44,7 +35,29 @@
               }
             },
             "motpartsPersonident": "VergeMotpartsPersonident2",
-            "omfang": "personligeInteresser"
+            "omfang": "personligeInteresser",
+            "tjenesteomraade": [
+              {
+                "tjenesteoppgave": "arbeid",
+                "tjenestevirksomhet": "nav"
+              },
+              {
+                "tjenesteoppgave": "familie",
+                "tjenestevirksomhet": "nav"
+              },
+              {
+                "tjenesteoppgave": "hjelpemidler",
+                "tjenestevirksomhet": "nav"
+              },
+              {
+                "tjenesteoppgave": "pensjon",
+                "tjenestevirksomhet": "nav"
+              },
+              {
+                "tjenesteoppgave": "sosialeTjenester",
+                "tjenestevirksomhet": "nav"
+              }
+            ]
           },
           "folkeregistermetadata": {
             "ajourholdstidspunkt":  "2021-03-02T13:00:42",

--- a/src/test/resources/pdl-hentVerge-response.json
+++ b/src/test/resources/pdl-hentVerge-response.json
@@ -11,6 +11,13 @@
               "mellomnavn": "vergeMellomnavn1",
               "etternavn": "vergeEtternavn1"
             },
+            "identifiserendeInformasjon": {
+              "navn": {
+                "fornavn": "vergeFornavn1",
+                "mellomnavn": "vergeMellomnavn1",
+                "etternavn": "vergeEtternavn1"
+              }
+            },
             "motpartsPersonident": "VergeMotpartsPersonident1",
             "omfang": "oekonomiskeInteresser"
           },
@@ -27,6 +34,13 @@
               "fornavn": "vergeFornavn2",
               "mellomnavn": "vergeMellomnavn2",
               "etternavn": "vergeEtternavn2"
+            },
+            "identifiserendeInformasjon": {
+              "navn": {
+                "fornavn": "vergeFornavn2",
+                "mellomnavn": "vergeMellomnavn2",
+                "etternavn": "vergeEtternavn2"
+              }
             },
             "motpartsPersonident": "VergeMotpartsPersonident2",
             "omfang": "personligeInteresser"

--- a/src/test/resources/pdl-hentVerge-response.json
+++ b/src/test/resources/pdl-hentVerge-response.json
@@ -23,7 +23,8 @@
           },
           "folkeregistermetadata": {
             "ajourholdstidspunkt":  "2021-03-02T13:00:42",
-            "gyldighetstidspunkt":  "2021-03-02T13:00:42"
+            "gyldighetstidspunkt":  "2021-03-02T13:00:42",
+            "opphoerstidspunkt": "2021-03-12T13:00:42"
           }
         },
         {
@@ -47,7 +48,8 @@
           },
           "folkeregistermetadata": {
             "ajourholdstidspunkt":  "2021-03-02T13:00:42",
-            "gyldighetstidspunkt":  "2021-03-02T13:00:42"
+            "gyldighetstidspunkt":  "2021-03-02T13:00:42",
+            "opphoerstidspunkt": "2021-03-12T13:00:42"
           }
         }
       ]


### PR DESCRIPTION
## Beskriv endringene

PDL har endret på endepunktet sitt i nov 2023 (fordi skatteetaten har gjort endringer). Sånn jeg har forstått det:

1. Navn er deprecated, erstattes med å slå opp fnr på vergen og hente navnet på den måten. I de tilfeller fnr ikke er tilgjengelig, så finnes det "identifiserendeinformasjon" med navn man kan bruke i stedet. 
2. Omfang er nå kun på historiske data fra før nov 2023. Er erstattet med "tjenesteområder" etter denne datoen (unntatt personer under 18 år). Dette er ikke oppdatert i dolly, så er litt irriterende. 
3. Historikk: denne er satt til false, så skal egentlig kun få med aktive vergemål. I dolly kan man sette sluttdato, og denne blir lagret som "opphoerttidspunkt", men dolly er ikke oppdatert til å sette et avsluttet vergemål, så alle kommer med selv om de har et opphørttidspunkt (dette er ikke tilfellet for prod). 


## Har du testet endringene i dev-miljøet?
- [x] Ja, jeg/vi har testet i dev
