### PR TITLE
Oppdatert urlen til appen arbeidssøkerregisteret

### DIFF
--- a/nais-dev-gcp.yaml
+++ b/nais-dev-gcp.yaml
@@ -75,7 +75,7 @@ spec:
           namespace: team-rocket
         - application: poao-tilgang
           namespace: poao
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
         - application: skjermede-personer-pip
           namespace: nom
@@ -127,9 +127,9 @@ spec:
     - name: VEILARBOPPFOLGING_URL
       value: http://veilarboppfolging.poao/veilarboppfolging
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
-      value: http://paw-arbeidssoekerregisteret-api-oppslag.paw
+      value: http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
-      value: api://dev-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default
+      value: api://dev-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default
     - name: NORG2_URL
       value: http://norg2.org/norg2
     - name: NORG2_SCOPE

--- a/nais-prod-gcp.yaml
+++ b/nais-prod-gcp.yaml
@@ -71,7 +71,7 @@ spec:
           namespace: team-rocket
         - application: poao-tilgang
           namespace: poao
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
         - application: skjermede-personer-pip
           namespace: nom
@@ -124,9 +124,9 @@ spec:
     - name: VEILARBOPPFOLGING_URL
       value: http://veilarboppfolging.poao/veilarboppfolging
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_URL
-      value: http://paw-arbeidssoekerregisteret-api-oppslag.paw
+      value: http://paw-arbeidssoekerregisteret-api-oppslag-v2.paw
     - name: OPPSLAG_ARBEIDSSOEKERREGISTERET_SCOPE
-      value: api://prod-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag/.default
+      value: api://prod-gcp.paw.paw-arbeidssoekerregisteret-api-oppslag-v2/.default
     - name: NORG2_URL
       value: http://norg2.org/norg2
     - name: NORG2_SCOPE


### PR DESCRIPTION
følgende tjeneste vil etterhvert fases ut:
ingress: https://oppslag-arbeidssoekerregisteret.intern.nav.no/
service discovery: paw-arbeidssoekerregisteret-api-oppslag
Erstatning er alt klar i dev og prod. Den er tilgjengelig via service discovery: paw-arbeidssoekerregisteret-api-oppslag-v2

https://trello.com/c/XncmtMMv/1090-endre-paw-arbeidssokerregister-til-v2
## Har du testet endringene i dev-miljøet?
- [ ] Ja, jeg/vi har testet i dev
